### PR TITLE
ChatGPT for job writing

### DIFF
--- a/.changeset/curvy-socks-tease.md
+++ b/.changeset/curvy-socks-tease.md
@@ -1,0 +1,7 @@
+---
+"apollo": minor
+---
+
+- Support Typescript services
+- Add describe_adaptor service
+- Add job_chat service

--- a/platform/src/bridge.ts
+++ b/platform/src/bridge.ts
@@ -12,6 +12,7 @@ import { rm } from "node:fs/promises";
 */
 export const run = async (
   scriptName: string,
+  port: number, // needed for self-calling services in pythonland
   args: JSON,
   onLog?: (str: string) => void
 ) => {
@@ -50,9 +51,18 @@ export const run = async (
 
     // Use nodejs spawn
     // I seem to have to use this because the bun stream doesn't work with readline
+
     const proc = spawn(
       "poetry",
-      ["run", "python", "services/entry.py", scriptName, inputPath, outputPath],
+      [
+        "run",
+        "python",
+        "services/entry.py",
+        scriptName,
+        inputPath,
+        outputPath,
+        `${port}`,
+      ],
       {}
     );
 
@@ -70,7 +80,7 @@ export const run = async (
 
       try {
         await rm(inputPath);
-        await rm(outputPath);
+        // await rm(outputPath);
       } catch (e) {
         console.error("Error removing temporary files");
         console.error(e);

--- a/platform/src/bridge.ts
+++ b/platform/src/bridge.ts
@@ -80,7 +80,7 @@ export const run = async (
 
       try {
         await rm(inputPath);
-        // await rm(outputPath);
+        await rm(outputPath);
       } catch (e) {
         console.error("Error removing temporary files");
         console.error(e);

--- a/platform/src/server.ts
+++ b/platform/src/server.ts
@@ -8,10 +8,10 @@ export const app = new Elysia();
 
 app.use(html());
 
-await setupDir(app);
-await setupServices(app);
+export default async (port: number | string = 3000) => {
+  await setupDir(app);
+  await setupServices(app, port);
 
-export default (port: number | string = 3000) => {
   console.log("Apollo Server listening on ", port);
   app.listen(port);
 };

--- a/platform/src/util/describe-modules.ts
+++ b/platform/src/util/describe-modules.ts
@@ -2,8 +2,9 @@ import { readFile, readdir } from "node:fs/promises"; // no bun api yet
 
 export type ModuleDescription = {
   name: string;
+  type: "py" | "ts";
 
-  // TODO - pull out metadata from each
+  handler?: (payload: any, onLog?: (str: string) => void) => Promise<any>;
   summary?: string;
   readme?: string;
 };
@@ -17,9 +18,36 @@ export default async (location: string): Promise<ModuleDescription[]> => {
 
   const result: ModuleDescription[] = [];
   for (const srv of services) {
+    let type: "py" | "ts";
+    let handler;
+
+    const hasPyIndex = await Bun.file(
+      `${location}/${srv.name}/${srv.name}.py`
+    ).exists();
+    if (hasPyIndex) {
+      type = "py";
+    } else {
+      const hasTsIndex = await Bun.file(
+        `${location}/${srv.name}/${srv.name}.ts`
+      ).exists();
+      if (hasTsIndex) {
+        type = "ts";
+        const mod = await import(`${location}/${srv.name}/${srv.name}.ts`);
+        handler = mod.default;
+      } else {
+        console.warn("WARNING: no index file found for ", srv.name);
+        continue;
+      }
+    }
+
+    // if no index file, skip it with a warning
     const s: ModuleDescription = {
       name: srv.name,
+      // is this a python or js service?
+      type,
+      handler,
     };
+
     try {
       const rm = await readFile(`${location}/${srv.name}/README.md`, "utf8");
 

--- a/platform/src/util/describe-modules.ts
+++ b/platform/src/util/describe-modules.ts
@@ -4,7 +4,11 @@ export type ModuleDescription = {
   name: string;
   type: "py" | "ts";
 
-  handler?: (payload: any, onLog?: (str: string) => void) => Promise<any>;
+  handler?: (
+    port: number,
+    payload: any,
+    onLog?: (str: string) => void
+  ) => Promise<any>;
   summary?: string;
   readme?: string;
 };

--- a/services/describe_adaptor/README.md
+++ b/services/describe_adaptor/README.md
@@ -1,0 +1,39 @@
+This is a Typescript that can return a representation of the API of any given
+adaptor.
+
+## Useage
+
+Pass an adaptor name and version in the payload:
+
+```
+{
+  adaptor: '@openfn/language-http@2.0.0
+}
+```
+
+And it'll return a representation of that adaptor (and dependencies):
+
+```
+{
+  '@openfn/language-common': {
+      version: '1.0.0',
+      description: ' /* d.ts files merged into one */
+  }
+  '@openfn/language-http': {
+    version: '1.0.0',
+    description: ' /* d.ts files merged into one */
+  }
+}
+```
+
+Right now it'll only support one adaptor, but it woudl be easy to support an
+array of inputs
+
+## Representation formats
+
+Right now the function will only return the raw d.ts representation of the
+adaptor (which is what our current AI services require).
+
+Later, we should also return a proprietary docs format used by adaptor-docs in
+Lightning (If there's a solid and simple standard for describing a JS library in
+JSON, I'm all for it)

--- a/services/describe_adaptor/describe_adaptor.ts
+++ b/services/describe_adaptor/describe_adaptor.ts
@@ -1,5 +1,71 @@
+import { fetchDTSListing, fetchFile, getNameAndVersion } from "./util";
+
 // TODO log streaming is not implemented yet
 // This is not designed to be called from the CLI
 export default (payload: any, onLog: any) => {
   console.log("hello from  TS land!");
+  console.log(payload);
+
+  return describePackage(payload.adaptor);
+};
+
+// This implementation is copied and adaptored from describe-package
+export const describePackage = async (
+  specifier: string
+): Promise<Record<string, string>> => {
+  const { name, version } = getNameAndVersion(specifier);
+
+  const results: Record<string, string[]> = {};
+
+  if (name != "@openfn/language-common") {
+    console.log("Loading files for common...");
+    const commonFiles: string[] = [];
+    results["@openfn/language-common"] = commonFiles;
+
+    // Include language-common in the project model
+    // (I don't expect this to be permanent)
+
+    // First work out the correct version
+    const pkgStr = await fetchFile(`${specifier}/package.json`);
+    const pkg = JSON.parse(pkgStr);
+
+    if (pkg.dependencies["@openfn/language-common"]) {
+      const commonSpecifier = `@openfn/language-common@${pkg.dependencies[
+        "@openfn/language-common"
+      ].replace("^", "")}`;
+
+      const common = await fetchDTSListing(commonSpecifier);
+      for await (const fileName of common) {
+        const f = await fetchFile(`${commonSpecifier}${fileName}`);
+        commonFiles.push(f);
+      }
+    }
+    console.log("common done!");
+  }
+
+  console.log("Loading files for adaptor...");
+
+  // Now fetch the listings for the actual package
+  const fileNames = await fetchDTSListing(specifier);
+
+  const packageFiles: string[] = [];
+  results[name] = packageFiles;
+  for await (const fileName of fileNames) {
+    if (!/beta\.d\.ts$/.test(fileName)) {
+      const f = await fetchFile(`${specifier}${fileName}`);
+      packageFiles.push(f);
+    }
+  }
+
+  console.log("adaptors done!");
+
+  const finalResults: Record<string, string> = {};
+  for (const k in results) {
+    finalResults[k] = {
+      name: k,
+      descriptionn: results[k].join("\n\n"),
+    };
+  }
+
+  return finalResults;
 };

--- a/services/describe_adaptor/describe_adaptor.ts
+++ b/services/describe_adaptor/describe_adaptor.ts
@@ -1,0 +1,5 @@
+// TODO log streaming is not implemented yet
+// This is not designed to be called from the CLI
+export default (payload: any, onLog: any) => {
+  console.log("hello from  TS land!");
+};

--- a/services/describe_adaptor/describe_adaptor.ts
+++ b/services/describe_adaptor/describe_adaptor.ts
@@ -2,7 +2,7 @@ import { fetchDTSListing, fetchFile, getNameAndVersion } from "./util";
 
 // TODO log streaming is not implemented yet
 // This is not designed to be called from the CLI
-export default (payload: any, onLog: any) => {
+export default (port: number, payload: any, onLog: any) => {
   console.log("hello from  TS land!");
   console.log(payload);
 

--- a/services/describe_adaptor/describe_adaptor.ts
+++ b/services/describe_adaptor/describe_adaptor.ts
@@ -63,7 +63,7 @@ export const describePackage = async (
   for (const k in results) {
     finalResults[k] = {
       name: k,
-      descriptionn: results[k].join("\n\n"),
+      description: results[k].join("\n\n"),
     };
   }
 

--- a/services/describe_adaptor/util.ts
+++ b/services/describe_adaptor/util.ts
@@ -1,0 +1,53 @@
+export const getNameAndVersion = (specifier: string) => {
+  let name;
+  let version;
+
+  const atIndex = specifier.lastIndexOf("@");
+  if (atIndex > 0) {
+    name = specifier.substring(0, atIndex);
+    version = specifier.substring(atIndex + 1);
+  } else {
+    name = specifier;
+  }
+
+  return { name, version } as { name: string; version: string };
+};
+
+export async function fetchFile(path: string) {
+  const resolvedPath = `https://cdn.jsdelivr.net/npm/${path}`;
+  console.log(resolvedPath);
+  const response = await fetch(resolvedPath);
+
+  if (response.status === 200) {
+    return response.text();
+  }
+
+  throw new Error(
+    `Failed getting file at: ${path} got: ${response.status} ${response.statusText}`
+  );
+}
+
+export async function fetchFileListing(packageName: string) {
+  const response = await fetch(
+    `https://data.jsdelivr.com/v1/package/npm/${packageName}/flat`
+  );
+
+  if (response.status != 200) {
+    throw new Error(
+      `Failed getting file listing for: ${packageName} got: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const listing = await response.json();
+  return listing.files?.map(({ name }: any) => name);
+}
+
+const dtsExtension = /\.d\.ts$/;
+
+export async function* fetchDTSListing(packageName: string) {
+  for (const f of await fetchFileListing(packageName)) {
+    if (dtsExtension.test(f)) {
+      yield f;
+    }
+  }
+}

--- a/services/entry.py
+++ b/services/entry.py
@@ -1,6 +1,7 @@
 import sys
 import json
 from dotenv import load_dotenv
+from util import set_apollo_port
 import uuid
 
 # This will load from the ../.env file (at root)
@@ -36,13 +37,18 @@ if __name__ == "__main__":
     input_path = sys.argv[2]
     output_path = None
 
-    if len(sys.argv) == 4:
+    if len(sys.argv) == 5:
         output_path = sys.argv[3]
     else:
         print("auto-generating output path")
         id = uuid.uuid4()
         output_path = "tmp/data/{}.json".format(id)
         print("Result will be output to {}".format(output_path))
+
+    apollo_port = sys.argv[4]
+    if apollo_port is not None:
+        print("Setting apollo port to {}".format(apollo_port))
+        set_apollo_port(apollo_port)
 
     print("Calling services/{} ...".format(mod_name))
 

--- a/services/job_chat/README.md
+++ b/services/job_chat/README.md
@@ -1,0 +1,102 @@
+## Job Chat
+
+The Job Chat service enables a chat interface to uses writing an OpenFn job.
+
+Clients must submit as much context about the job as they can (the current
+expression, adaptor, input etc), along with the chat history, and a response
+will be generated (along with a new history).
+
+The Job Chat service is designed to be integrated with Lightning.
+
+## Usage
+
+Here is a minimal payload with a user question and no history:
+
+```json
+{
+  "content": "how do I insert a new sobject record?",
+  "context": {
+    "expression": "// write your job code here",
+    "adaptor": "@openfn/language-salesforce@4.6.10"
+  }
+}
+```
+
+To start a new chat with curl:
+
+```
+curl -X POST https://apollo-staging.openfn.org/services/job_chat --json @tmp/payload.json
+```
+
+With the CLI, returning to stdout:
+
+```
+openfn apollo job_chat tmp/payload.json -O
+```
+
+To run direct from this repo (note that the server must be started):
+
+```
+bun py job_chat tmp/payload.json
+```
+
+## Implementation
+
+The service works by building a prompt with all the relevant context and sending
+that along to a GPT model.
+
+If an adaptor is provided, a complete listing of the adaptor's API is sent to
+the model.
+
+At the time of writing, a basic intro to OpenFn job writing is included in the
+prompt. Later, we plan to use RAG processing to pull relevant information from
+the OpenFn doc site.
+
+The model is explicitly instructed to only answer questions about OpenFn and Job
+Writing.
+
+## Streaming
+
+Right now the service will return the complete response when loaded.
+
+Later, we may expose a streaming interface for better UX.
+
+## Payoad Reference
+
+The input payload is a JSON object with the following structure
+
+```json
+{
+  "api_key": "<OpenAI api key>",
+  "content": "The user's question",
+  "history": [
+    /* The complete chat history, as { role, content } objects */
+  ],
+  "context": {
+    "expression": "The user's job code",
+    "adaptor": "full specificer for the adaptor, eg @openfn/language-salesforce@4.10.0",
+    "input": {
+      /* The input state to the job */
+    },
+    "output": {
+      /** The output from the last run */
+    },
+    "log": "the log from the last run"
+  }
+}
+```
+
+All context is optional, as is history.
+
+## Response Reference
+
+The server returns the following JSON response:
+
+```json
+{
+  "response": "the GPT response as a string",
+  "history": [
+    /* Updated chat history */
+  ]
+}
+```

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -14,7 +14,7 @@ class Payload(DictObj):
     api_key: str
     content: str
     # history # list of {role , content } dicts
-    # context { expressio, adaptor, input, output, log  }
+    # context { expression, adaptor, input, output, log  }
 
 
 def main(dataDict) -> dict:

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -13,13 +13,15 @@ OPENAI_API_KEY = os.getenv(
 class Payload(DictObj):
     api_key: str
     content: str
-    # history:
-    # context:
+    # history # list of {role , content } dicts
+    # context { expressio, adaptor, input, output, log  }
 
 
 def main(dataDict) -> dict:
     data = Payload(dataDict)
-    result = generate(data.content, dataDict["history"], data.context, data.get("api_key"))
+    result = generate(
+        data.content, dataDict["history"] if "history" in dataDict else [], data.context, data.get("api_key")
+    )
     return result
 
 

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -1,0 +1,64 @@
+import os
+from openai import OpenAI
+from util import DictObj, createLogger
+from .prompt import build_prompt
+
+logger = createLogger("job_chat")
+
+OPENAI_API_KEY = os.getenv(
+    "OPENAI_API_KEY",
+)
+
+
+class Payload(DictObj):
+    api_key: str
+    content: str
+    # history:
+    # context:
+
+
+def main(dataDict) -> dict:
+    data = Payload(dataDict)
+    result = generate(data.content, dataDict["history"], data.context, data.get("api_key"))
+    return result
+
+
+def generate(content, history, context, api_key) -> str:
+    if api_key is None and isinstance(OPENAI_API_KEY, str):
+        logger.warn("Using default API key from environment")
+        api_key = OPENAI_API_KEY
+
+    # should we let users drive this?
+    model = "gpt-3.5-turbo"
+
+    client = OpenAI(api_key=api_key)
+    logger.info("OpenAI client loaded with {}".format(model))
+    prompt = build_prompt(content, history, context)
+
+    logger.info("--- PROMPT ---")
+    logger.info(prompt)
+    logger.info("--------------")
+
+    try:
+        logger.info("Generating")
+        max_tokens = 256  # TODO maybe take an option for this?
+        response = client.chat.completions.create(
+            messages=prompt,
+            model="gpt-3.5-turbo",
+            temperature=0,
+            max_tokens=max_tokens,
+        )
+        result = response.choices[0].message.content.strip()
+        if result is None:
+            logger.error("An error occurred during chat generation")
+        else:
+            logger.info("response from model:")
+            logger.info(content)
+            logger.info("done")
+
+        history.append({"role": "user", "content": content})
+        history.append({"role": "assistant", "content": result})
+
+        return {"response": result, "history": history}
+    except Exception as e:
+        logger.error(f"An error occurred chat code generation: {e}")

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -55,7 +55,9 @@ def generate(content, history, context, api_key) -> str:
             logger.error("An error occurred during chat generation")
         else:
             logger.info("response from model:")
-            logger.info(content)
+            logger.info("")
+            logger.info("\n" + result)
+            logger.info("")
             logger.info("done")
 
         history.append({"role": "user", "content": content})

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -14,12 +14,28 @@ questions related to openfn, javascript programming, and workflow automation.
 def build_context(context):
     message = []
 
-    if context.adaptor is not None:
+    if context.has("adaptor"):
         message.append("I am using the OpenFn {} adaptor, use functions provided by its API".format(context.adaptor))
 
         # TODO we should surely import the API here or something?
     else:
         message.append("I am using an OpenFn Adaptor to write my job.")
+
+    if context.has("expression"):
+        message.append(
+            "My code currently looks like this :```{}```\n\n You should try and re-use any relevant user code in your response".format(
+                context.expression
+            )
+        )
+
+    if context.has("input"):
+        "My input data is :\n\n```{}```".format(context.input)
+
+    if context.has("output"):
+        "My last output data was :\n\n```{}```".format(context.output)
+
+    if context.has("log"):
+        "My last log output was :\n\n```{}```".format(context.log)
 
     return {"role": "user", "content": "\n\n".join(message)}
 

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -2,6 +2,8 @@ from util import DictObj, createLogger
 
 logger = createLogger("job_chat.prompt")
 
+# RAG
+# Retrieval Augmented Generation
 system_message = """
 you are an agent helping a non-export user write a job for OpenFn,
 the worlds leading digital public good for workflow automation.
@@ -10,9 +12,86 @@ is very similar to JAVASCRIPT. you should STRICTLY ONLY answer
 questions related to openfn, javascript programming, and workflow automation.
 """
 
+# for now we're hard coding a sort of job writing 101 with code examples
+# Later we'll do some real RAG against the docsite
+job_writing_summary = """
+Here is a guide to job writing in OpenFn.
+
+A Job is a bunch of openfn dsl code which performs a particular task, like
+fetching data from Salesforce or converting JSON data to FHIR standard.
+
+Each job uses exactly one Adaptor to perform its task. The Adaptor provides a
+collection of Operations (helper functions) which makes it easy to communicate with
+a data source. The adaptor API for this job is provided below.
+
+An Operation is a factory function returns a function that takes state and returns state. A
+In other words:
+```
+const myOperation = (arg) => (state) => { /* do something with arg and state */ return state; }
+```
+
+The job code will be compiled into an array operation factories, which at runtime will be 
+executed in series, with state passed into each one.
+
+For example, here's how we issue a GET request with the http adaptor:
+```
+get('/patients');
+```
+The first argument to get is the path to request from (the configuration will tell
+the adaptor what base url to use). In this case we're passing a static string,
+but we can also pass a value from state:
+```
+get(state => state.endpoint);
+```
+This works because each operation's arguments allow a function to be passed,
+which will be lazily invoked at runtime with the latest state value.
+
+Job code should only contain Operations at the top level/scope - you MUST NOT
+include any other JavaScript statements at the top level.
+
+Job code is written in modern JavaScript, and although async/await is allowed
+inside a callback function (never at the top level), it is rarely used.
+
+Example job code with the HTTP adaptor:
+```
+get('/patients');
+each('$.data.patients[*]', (item, index) => {
+  item.id = `item-${index}`;
+});
+post('/patients', dataValue('patients'));
+```
+Example job code with the Salesforce adaptor:
+```
+each(
+  '$.form.participants[*]',
+  upsert('Person__c', 'Participant_PID__c', state => ({
+    Participant_PID__c: state.pid,
+    First_Name__c: state.participant_first_name,
+    Surname__c: state.participant_surname,
+  }))
+);
+```
+Example job code with the ODK adaptor:
+```
+each(
+  '$.data.data[*]',
+  create(
+    'ODK_Submission__c',
+    fields(
+      field('Site_School_ID_Number__c', dataValue('school')),
+      field('Date_Completed__c', dataValue('date')),
+      field('comments__c', dataValue('comments')),
+      field('ODK_Key__c', dataValue('*meta-instance-id*'))
+    )
+  )
+);
+```
+-----
+"""
+
 
 def build_context(context):
-    message = []
+    message = [job_writing_summary]
 
     if context.has("adaptor"):
         message.append("I am using the OpenFn {} adaptor, use functions provided by its API".format(context.adaptor))
@@ -46,7 +125,7 @@ def build_prompt(content, history, context):
     # push the system message
     prompt.append({"role": "system", "content": system_message})
 
-    # push the histor
+    # push the history
     prompt.extend(history)
 
     # add context as a seperate message here

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -1,4 +1,4 @@
-from util import DictObj, createLogger
+from util import createLogger, apollo
 
 logger = createLogger("job_chat.prompt")
 
@@ -97,6 +97,12 @@ def build_context(context):
         message.append("I am using the OpenFn {} adaptor, use functions provided by its API".format(context.adaptor))
 
         # TODO we should surely import the API here or something?
+        adaptor_docs = apollo("describe_adaptor", {"adaptor": context.adaptor})
+        for doc in adaptor_docs:
+            message.append("Typescript definitions for doc")
+            message.append(adaptor_docs[doc]["description"])
+        message.append("-------------------------")
+
     else:
         message.append("I am using an OpenFn Adaptor to write my job.")
 
@@ -122,10 +128,10 @@ def build_context(context):
 def build_prompt(content, history, context):
     prompt = []
 
-    # push the system message
+    # # push the system message
     prompt.append({"role": "system", "content": system_message})
 
-    # push the history
+    # # push the history
     prompt.extend(history)
 
     # add context as a seperate message here

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -96,7 +96,6 @@ def build_context(context):
     if context.has("adaptor"):
         message.append("I am using the OpenFn {} adaptor, use functions provided by its API".format(context.adaptor))
 
-        # TODO we should surely import the API here or something?
         adaptor_docs = apollo("describe_adaptor", {"adaptor": context.adaptor})
         for doc in adaptor_docs:
             message.append("Typescript definitions for doc")

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -127,14 +127,13 @@ def build_context(context):
 def build_prompt(content, history, context):
     prompt = []
 
-    # # push the system message
+    # push the system message
     prompt.append({"role": "system", "content": system_message})
 
-    # # push the history
+    # push the history
     prompt.extend(history)
 
     # add context as a seperate message here
-    # idk if this will work
     prompt.append(build_context(context))
 
     # Finally, append the latest message from the user

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -1,0 +1,43 @@
+from util import DictObj, createLogger
+
+logger = createLogger("job_chat.prompt")
+
+system_message = """
+you are an agent helping a non-export user write a job for OpenFn,
+the worlds leading digital public good for workflow automation.
+You are helping the user write a job in openfn's custom dsl, which
+is very similar to JAVASCRIPT. you should STRICTLY ONLY answer
+questions related to openfn, javascript programming, and workflow automation.
+"""
+
+
+def build_context(context):
+    message = []
+
+    if context.adaptor is not None:
+        message.append("I am using the OpenFn {} adaptor, use functions provided by its API".format(context.adaptor))
+
+        # TODO we should surely import the API here or something?
+    else:
+        message.append("I am using an OpenFn Adaptor to write my job.")
+
+    return {"role": "user", "content": "\n\n".join(message)}
+
+
+def build_prompt(content, history, context):
+    prompt = []
+
+    # push the system message
+    prompt.append({"role": "system", "content": system_message})
+
+    # push the histor
+    prompt.extend(history)
+
+    # add context as a seperate message here
+    # idk if this will work
+    prompt.append(build_context(context))
+
+    # Finally, append the latest message from the user
+    prompt.append({"role": "user", "content": content})
+
+    return prompt

--- a/services/util.py
+++ b/services/util.py
@@ -30,6 +30,8 @@ filename = None
 
 loggers = {}
 
+apollo_port = 3000
+
 
 def setLogOutput(f):
     global filename
@@ -38,6 +40,12 @@ def setLogOutput(f):
         print("[entry.py] writing logs to {}".format(f))
 
     filename = f
+
+
+def set_apollo_port(p):
+    global apollo_port
+
+    apollo_port = p
 
 
 def createLogger(name):
@@ -55,9 +63,8 @@ def createLogger(name):
 
 # call out to another apollo service through http
 def apollo(name, payload):
-    # TODO how do I do this properly?
-    # python land doesn't really even know about the server
-    # is env.port safe? Well maybe not
-    url = "http://localhost:3000/services/{}".format(name)
+    global apollo_port
+
+    url = "http://127.0.0.1:{}/services/{}".format(apollo_port, name)
     r = requests.post(url, payload)
     return r.json()

--- a/services/util.py
+++ b/services/util.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import requests
 
 
 # Thanks Joel! https://joelmccune.com/python-dictionary-as-object/
@@ -50,3 +51,13 @@ def createLogger(name):
         loggers[name] = logger
 
     return loggers[name]
+
+
+# call out to another apollo service through http
+def apollo(name, payload):
+    # TODO how do I do this properly?
+    # python land doesn't really even know about the server
+    # is env.port safe? Well maybe not
+    url = "http://localhost:3000/services/{}".format(name)
+    r = requests.post(url, payload)
+    return r.json()

--- a/services/util.py
+++ b/services/util.py
@@ -18,6 +18,9 @@ class DictObj:
             return self._dict[key]
         return None
 
+    def toDict(self):
+        return self._dict
+
 
 filename = None
 
@@ -34,8 +37,6 @@ def setLogOutput(f):
 
 
 def createLogger(name):
-    print("CREATE LOGGER  {}".format(name))
-
     # hmm. If I use a stream other than stdout,
     # I could send logger statements elsewhere
     # but I wouldn't be able to read it from the outside
@@ -44,7 +45,5 @@ def createLogger(name):
         logger = logging.getLogger(name)
 
         loggers[name] = logger
-    else:
-        print("RETURNING CACHED LOGGER")
 
     return loggers[name]

--- a/services/util.py
+++ b/services/util.py
@@ -18,6 +18,9 @@ class DictObj:
             return self._dict[key]
         return None
 
+    def has(self, key):
+        return key in self._dict
+
     def toDict(self):
         return self._dict
 


### PR DESCRIPTION
This PR introduces a chat service, designed eventual to be integrated into Lightning's Inspector panel

## Issue

#52

## How It Works

In a nutshell: call this service with a JSON object containing a user question, the chat history, and the user's current context (expression, adaptor, input, output, log).

We take the context and build a prompt, with some presets, then send it out to chatgpt.

I am currently working out the best way to build that prompt and where the context goes - I don't really want it duplicated on every step of the converstaion.

Right now I'm hard-coded to 3.5-turbo but it's trivial to parameter-drive this for a different openAI model.

## Payload
```
{
  "content": "how do insert a new sobject record",
  "history": [
    { "role": "user", "content": "good day" },
    { "role": "system", "content": "and a good day to you sir" }
  ],
  "context": {
    "expression": "// write your job code here",
    "adaptor": "salesforce",
    "input": { "data": [{ "name": "Joe", "id": "joec" }] },
    "output": null,
    "log": null
  }
}
```

## Response

```
{
  "response": "In your code snippet, you are not returning the object correctly...",
  "history": [
    { "role": "user", "content": "what is wrong with my code?" },
    {
      "role": "assistant",
      "content": "In your code snippet, you are not returning the object correctly..."
    }
  ]
}

```
## Adaptor APIs

[TODO] As a little experiment, I've included the typescript typings for Salesforce + common in this repo, so if you happen to use the salesforce adaptor you should get a lot more context and accuracy

This needs to be built out into a generalised service to fetch the API for an adaptor.  This feels an awful lot like the adaptor docs service that we want to move out of Lightning - but needs to be scoped as a different piece of work.

## TODO

* [x] Setup the read me
* [x] Explore different prompts and prompt techiques
* [x] Add some job writing boilerplate to the prompt (a few key examples)
* [x] Add adaptor API to the prompt (see [RAG for adaptors](https://github.com/OpenFn/apollo/pull/69#issuecomment-2154550720))
* [ ] Add docsite content to the prompt (see [RAG for docs](https://github.com/OpenFn/apollo/pull/69#issuecomment-2154571165))

## Examples

See the comment thread below for examples of particular queries