### PR TITLE
Refactor services entry point to use named arguments

### DIFF
--- a/platform/src/bridge.ts
+++ b/platform/src/bridge.ts
@@ -30,38 +30,16 @@ export const run = async (
     console.log("Initing output file at", outputPath);
     await Bun.write(outputPath, "");
 
-    // const proc = Bun.spawn(
-    //   [
-    //     "poetry",
-    //     "run",
-    //     "python",
-    //     "services/entry.py",
-    //     scriptName,
-    //     JSON.stringify(args),
-    //   ],
-    //   {
-    //     onExit: async (proc, exitCode, signalCode, error) => {
-    //       // exit handler
-    //       const result = Bun.file("out.json");
-    //       const text = await result.text();
-    //       resolve(JSON.parse(text));
-    //     },
-    //   }
-    // );
-
-    // Use nodejs spawn
-    // I seem to have to use this because the bun stream doesn't work with readline
-
     const proc = spawn(
       "poetry",
       [
         "run",
         "python",
         "services/entry.py",
-        scriptName,
-        inputPath,
-        outputPath,
-        `${port}`,
+        "--service", scriptName,
+        "--input", inputPath,
+        "--output", outputPath,
+        "--port", `${port}`,
       ],
       {}
     );

--- a/platform/src/bridge.ts
+++ b/platform/src/bridge.ts
@@ -36,14 +36,10 @@ export const run = async (
         "run",
         "python",
         "services/entry.py",
-        "--service",
         scriptName,
-        "--input",
-        inputPath,
-        "--output",
-        outputPath,
-        "--port",
-        `${port}`,
+        ...(inputPath ? ["--input", inputPath] : []),
+        ...(outputPath ? ["--output", outputPath] : []),
+        ...(port ? ["--port", `${port}`] : []),
       ],
       {}
     );

--- a/platform/src/bridge.ts
+++ b/platform/src/bridge.ts
@@ -36,10 +36,14 @@ export const run = async (
         "run",
         "python",
         "services/entry.py",
-        "--service", scriptName,
-        "--input", inputPath,
-        "--output", outputPath,
-        "--port", `${port}`,
+        "--service",
+        scriptName,
+        "--input",
+        inputPath,
+        "--output",
+        outputPath,
+        "--port",
+        `${port}`,
       ],
       {}
     );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ optional = true
 [tool.poetry.group.ft.dependencies]
 torch = "^2.3.0"
 
+[tool.poetry.group.dev]
+optional = false
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.4"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/services/embeddings_demo/README.md
+++ b/services/embeddings_demo/README.md
@@ -13,5 +13,5 @@ This demo currently uses the Zilliz embedding storage provider for OpenAI embedd
 This demo can be run from the services folder via the entry.py module:
 
 ```bash
-python entry.py embeddings_demo embeddings_demo/demo_data/input_data.json tmp/output.json
+python entry.py embeddings_demo --input embeddings_demo/demo_data/input_data.json --output tmp/output.json
 ```

--- a/services/entry.py
+++ b/services/entry.py
@@ -39,7 +39,7 @@ def call(
         m = __import__(module_name, fromlist=["main"])
         result = m.main(data)
     except ModuleNotFoundError as e:
-        return {"type": "INTERNAL_ERROR", "code": 500, "message": str(e)}
+        return ApolloError(code=500, message=str(e), type="INTERNAL_ERROR").to_dict()
     except ApolloError as e:
         result = e.to_dict()
     except Exception as e:

--- a/services/entry.py
+++ b/services/entry.py
@@ -31,9 +31,9 @@ def call(
             with open(input_path, "r") as f:
                 data = json.load(f)
         except FileNotFoundError:
-            return {"type": "INTERNAL_ERROR", "code": 500, "message": f"Input file not found: {input_path}"}
+            return ApolloError(code=500, message=f"Input file not found: {input_path}", type="INTERNAL_ERROR").to_dict()
         except json.JSONDecodeError:
-            return {"type": "INTERNAL_ERROR", "code": 500, "message": "Invalid JSON input"}
+            return ApolloError(code=500, message="Invalid JSON input", type="INTERNAL_ERROR").to_dict()
 
     try:
         m = __import__(module_name, fromlist=["main"])

--- a/services/entry.py
+++ b/services/entry.py
@@ -1,25 +1,30 @@
 import sys
 import json
 import uuid
+import argparse
 from dotenv import load_dotenv
 from util import set_apollo_port, ApolloError
 
 load_dotenv()
 
 
-def call(service: str, input_path: str, output_path: str) -> dict:
+def call(*, service: str, input_path: str, output_path: str, apollo_port: int = None) -> dict:
     """
     Dynamically imports a module and invokes its main function with input data.
 
-    :param service: The name of the service/module to invoke.
-    :param input_path: Path to the input JSON file.
-    :param output_path: Path to write the output JSON file.
-    :return: Result from the service as a dictionary.
+    :param service: The name of the service/module to invoke
+    :param input_path: Path to the input JSON file
+    :param output_path: Path to write the output JSON file
+    :param apollo_port: Optional port number for Apollo server
+    :return: Result from the service as a dictionary
     """
     module_name = f"{service}.{service}"
 
-    with open(input_path, "r") as f:
-        data = json.load(f)
+    try:
+        with open(input_path, "r") as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        return {"type": "INTERNAL_ERROR", "code": 500, "message": "Invalid JSON input"}
 
     try:
         m = __import__(module_name, fromlist=["main"])
@@ -42,30 +47,38 @@ def call(service: str, input_path: str, output_path: str) -> dict:
 def main():
     """
     Entry point when the script is run directly.
-    Reads arguments from stdin and calls the appropriate service.
+    Uses argparse for better argument handling.
     """
-    mod_name = sys.argv[1]
-    input_path = sys.argv[2]
-    output_path = None
+    parser = argparse.ArgumentParser(description='OpenFn Apollo Service Runner')
+    parser.add_argument('--service', '-s', required=True,
+                      help='Name of the service to run')
+    parser.add_argument('--input', '-i', required=True,
+                      help='Path to input JSON file')
+    parser.add_argument('--output', '-o',
+                      help='Path to output JSON file (auto-generated if not provided)')
+    parser.add_argument('--port', '-p', type=int,
+                      help='Apollo server port number')
 
-    if len(sys.argv) >= 5:
-        output_path = sys.argv[3]
-    else:
-        print("Auto-generating output path...")
+    args = parser.parse_args()
+
+    if not args.output:
         id = uuid.uuid4()
-        output_path = f"tmp/data/{id}.json"
-        print(f"Result will be output to {output_path}")
+        args.output = f"tmp/data/{id}.json"
+        print(f"Result will be output to {args.output}")
 
-    if len(sys.argv) >= 5:
-        apollo_port = sys.argv[4]
-        if apollo_port:
-            print(f"Setting Apollo port to {apollo_port}")
-            set_apollo_port(apollo_port)
+    if args.port:
+        print(f"Setting Apollo port to {args.port}")
+        set_apollo_port(args.port)
 
-    print(f"Calling services/{mod_name} ...")
+    print(f"Calling services/{args.service} ...")
     print()
 
-    result = call(mod_name, input_path, output_path)
+    result = call(
+        service=args.service,
+        input_path=args.input,
+        output_path=args.output,
+        apollo_port=args.port
+    )
 
     print()
     print("Done!")

--- a/services/entry.py
+++ b/services/entry.py
@@ -8,14 +8,14 @@ from util import set_apollo_port, ApolloError
 load_dotenv()
 
 
-def call(*, service: str, input_path: str, output_path: str, apollo_port: int = None) -> dict:
+def call(*, service: str, input_path: str, output_path: str, apollo_port: int) -> dict:
     """
     Dynamically imports a module and invokes its main function with input data.
 
     :param service: The name of the service/module to invoke
     :param input_path: Path to the input JSON file
     :param output_path: Path to write the output JSON file
-    :param apollo_port: Optional port number for Apollo server
+    :param apollo_port: Port number for Apollo server
     :return: Result from the service as a dictionary
     """
     module_name = f"{service}.{service}"
@@ -32,11 +32,7 @@ def call(*, service: str, input_path: str, output_path: str, apollo_port: int = 
     except ApolloError as e:
         result = e.to_dict()
     except Exception as e:
-        result = ApolloError(
-            code=500,
-            message=str(e),
-            type="INTERNAL_ERROR"
-        ).to_dict()
+        result = ApolloError(code=500, message=str(e), type="INTERNAL_ERROR").to_dict()
 
     with open(output_path, "w") as f:
         json.dump(result, f)
@@ -47,17 +43,13 @@ def call(*, service: str, input_path: str, output_path: str, apollo_port: int = 
 def main():
     """
     Entry point when the script is run directly.
-    Uses argparse for better argument handling.
+    Reads arguments from stdin and calls the appropriate service.
     """
-    parser = argparse.ArgumentParser(description='OpenFn Apollo Service Runner')
-    parser.add_argument('--service', '-s', required=True,
-                      help='Name of the service to run')
-    parser.add_argument('--input', '-i', required=True,
-                      help='Path to input JSON file')
-    parser.add_argument('--output', '-o',
-                      help='Path to output JSON file (auto-generated if not provided)')
-    parser.add_argument('--port', '-p', type=int,
-                      help='Apollo server port number')
+    parser = argparse.ArgumentParser(description="OpenFn Apollo Service Runner")
+    parser.add_argument("--service", "-s", required=True, help="Name of the service to run")
+    parser.add_argument("--input", "-i", required=True, help="Path to input JSON file")
+    parser.add_argument("--output", "-o", help="Path to output JSON file (auto-generated if not provided)")
+    parser.add_argument("--port", "-p", type=int, help="Apollo server port number")
 
     args = parser.parse_args()
 
@@ -73,12 +65,7 @@ def main():
     print(f"Calling services/{args.service} ...")
     print()
 
-    result = call(
-        service=args.service,
-        input_path=args.input,
-        output_path=args.output,
-        apollo_port=args.port
-    )
+    result = call(service=args.service, input_path=args.input, output_path=args.output, apollo_port=args.port)
 
     print()
     print("Done!")

--- a/services/entry.py
+++ b/services/entry.py
@@ -8,7 +8,9 @@ from util import set_apollo_port, ApolloError
 load_dotenv()
 
 
-def call(service: str, *, input_path: str | None = None, output_path: str | None = None, apollo_port: int | None = None) -> dict:
+def call(
+    service: str, *, input_path: str | None = None, output_path: str | None = None, apollo_port: int | None = None
+) -> dict:
     """
     Dynamically imports a module and invokes its main function with input data.
 
@@ -19,8 +21,8 @@ def call(service: str, *, input_path: str | None = None, output_path: str | None
     :return: Result from the service as a dictionary
     """
     if apollo_port is not None:
-        set_apollo_port(apollo_port)  # Set the port if provided
-        
+        set_apollo_port(apollo_port)
+
     module_name = f"{service}.{service}"
 
     data = {}
@@ -75,17 +77,12 @@ def main():
     print(f"Calling services/{args.service} ...")
     print()
 
-    result = call(
-        service=args.service, 
-        input_path=args.input, 
-        output_path=args.output, 
-        apollo_port=args.port
-    )
+    result = call(service=args.service, input_path=args.input, output_path=args.output, apollo_port=args.port)
 
     print()
     print("Done!")
     print(result)
-    
+
     return result
 
 

--- a/services/entry_test.py
+++ b/services/entry_test.py
@@ -1,0 +1,62 @@
+import pytest
+import json
+import os
+from pathlib import Path
+from entry import call
+
+def test_echo_service():
+    # Setup test paths
+    input_path = "tmp/test_input.json"
+    output_path = "tmp/test_output.json"
+    test_data = {"test": "data"}
+    
+    # Ensure tmp directory exists
+    Path("tmp").mkdir(exist_ok=True)
+    
+    # Write test input
+    with open(input_path, "w") as f:
+        json.dump(test_data, f)
+    
+    try:
+        # Call echo service with named arguments
+        result = call(
+            service="echo",
+            input_path=input_path,
+            output_path=output_path
+        )
+        
+        # Verify result
+        assert result == test_data
+        
+        # Verify output file
+        with open(output_path, "r") as f:
+            output_data = json.load(f)
+        assert output_data == test_data
+        
+    finally:
+        # Cleanup
+        for file in [input_path, output_path]:
+            if os.path.exists(file):
+                os.remove(file)
+
+def test_error_handling():
+    input_path = "tmp/test_input.json"
+    output_path = "tmp/test_output.json"
+    
+    # Write invalid JSON
+    with open(input_path, "w") as f:
+        f.write("invalid json")
+    
+    try:
+        result = call(
+            service="non_existent_service",
+            input_path=input_path,
+            output_path=output_path
+        )
+        assert result["type"] == "INTERNAL_ERROR"
+        assert result["code"] == 500
+    finally:
+        # Cleanup
+        for file in [input_path, output_path]:
+            if os.path.exists(file):
+                os.remove(file) 

--- a/services/entry_test.py
+++ b/services/entry_test.py
@@ -4,59 +4,53 @@ import os
 from pathlib import Path
 from entry import call
 
+
 def test_echo_service():
     # Setup test paths
     input_path = "tmp/test_input.json"
     output_path = "tmp/test_output.json"
     test_data = {"test": "data"}
-    
+
     # Ensure tmp directory exists
     Path("tmp").mkdir(exist_ok=True)
-    
+
     # Write test input
     with open(input_path, "w") as f:
         json.dump(test_data, f)
-    
+
     try:
         # Call echo service with named arguments
-        result = call(
-            service="echo",
-            input_path=input_path,
-            output_path=output_path
-        )
-        
+        result = call(service="echo", input_path=input_path, output_path=output_path, apollo_port=3000)
+
         # Verify result
         assert result == test_data
-        
+
         # Verify output file
         with open(output_path, "r") as f:
             output_data = json.load(f)
         assert output_data == test_data
-        
+
     finally:
         # Cleanup
         for file in [input_path, output_path]:
             if os.path.exists(file):
                 os.remove(file)
 
+
 def test_error_handling():
     input_path = "tmp/test_input.json"
     output_path = "tmp/test_output.json"
-    
+
     # Write invalid JSON
     with open(input_path, "w") as f:
         f.write("invalid json")
-    
+
     try:
-        result = call(
-            service="non_existent_service",
-            input_path=input_path,
-            output_path=output_path
-        )
+        result = call(service="non_existent_service", input_path=input_path, output_path=output_path, apollo_port=3000)
         assert result["type"] == "INTERNAL_ERROR"
         assert result["code"] == 500
     finally:
         # Cleanup
         for file in [input_path, output_path]:
             if os.path.exists(file):
-                os.remove(file) 
+                os.remove(file)

--- a/services/entry_test.py
+++ b/services/entry_test.py
@@ -5,18 +5,19 @@ from pathlib import Path
 from entry import call, main
 import argparse
 from unittest.mock import patch
-from util import set_apollo_port, apollo  # Add apollo import
+from util import apollo
+
 
 def setup_module():
     """Setup test directories"""
     Path("tmp/data").mkdir(parents=True, exist_ok=True)
-    # Reset apollo_port to default
-    set_apollo_port(3000)
+
 
 def test_minimal_call():
     """Test calling with just the service name"""
-    result = call("echo")  # Only service name required
-    assert result == {}  # Empty dict when no input provided
+    result = call("echo")
+    assert result == {}
+
 
 def test_call_with_input():
     """Test calling with service name and input"""
@@ -29,65 +30,46 @@ def test_call_with_input():
     result = call("echo", input_path=input_path)
     assert result == test_data
 
+
 def test_command_line_minimal():
     """Test the absolute minimum command line usage"""
-    test_args = argparse.Namespace(
-        service="echo",  # Only required argument
-        input=None,
-        output=None,
-        port=None
-    )
+    test_args = argparse.Namespace(service="echo", input=None, output=None, port=None)
 
-    with patch('argparse.ArgumentParser.parse_args', return_value=test_args):
+    with patch("argparse.ArgumentParser.parse_args", return_value=test_args):
         result = main()
         assert result == {}
 
+
 def test_auto_generated_output():
     """Test that output path is auto-generated when not provided"""
-    test_args = argparse.Namespace(
-        service="echo",
-        input=None,
-        output=None,
-        port=None
-    )
+    test_args = argparse.Namespace(service="echo", input=None, output=None, port=None)
 
-    with patch('argparse.ArgumentParser.parse_args', return_value=test_args):
-        result = main()
-        # Check that an output file was created in tmp/data
+    with patch("argparse.ArgumentParser.parse_args", return_value=test_args):
+        main()
         files = list(Path("tmp/data").glob("*.json"))
         assert len(files) > 0
 
+
 def test_port_setting():
     """Test that port is properly set when provided"""
-    test_args = argparse.Namespace(
-        service="echo",
-        input=None,
-        output=None,
-        port=5000
-    )
+    test_args = argparse.Namespace(service="echo", input=None, output=None, port=5000)
 
-    with patch('argparse.ArgumentParser.parse_args', return_value=test_args):
-        # Reset port before test
-        set_apollo_port(3000)
-        result = main()
-        
-        # Instead of checking the global variable, verify the behavior
-        # by making a request using the apollo() function
-        with patch('requests.post') as mock_post:
+    with patch("argparse.ArgumentParser.parse_args", return_value=test_args):
+        main()
+
+        with patch("requests.post") as mock_post:
             mock_post.return_value.json.return_value = {"test": "data"}
             apollo("test", {})
-            # Verify the URL used contains the correct port
-            mock_post.assert_called_with(
-                "http://127.0.0.1:5000/services/test",
-                {}
-            )
+            mock_post.assert_called_with("http://127.0.0.1:5000/services/test", {})
+
 
 def test_invalid_service():
     """Test handling of invalid service name"""
     result = call("nonexistent_service")
-    assert result["type"] == "INTERNAL_ERROR"  # Check error structure instead
+    assert result["type"] == "INTERNAL_ERROR"
     assert result["code"] == 500
     assert "No module named" in result["message"]
+
 
 def test_invalid_input_file():
     """Test handling of nonexistent input file"""
@@ -96,24 +78,23 @@ def test_invalid_input_file():
         assert result["type"] == "INTERNAL_ERROR"
         assert result["code"] == 500
     except FileNotFoundError:
-        # Update entry.py to handle this error case
         pytest.fail("FileNotFoundError should be caught and returned as error dict")
+
 
 def test_output_file_writing():
     """Test that output is written to specified file"""
     output_path = "tmp/test_output.json"
     test_data = {"test": "data"}
-    
+
     result = call("echo", output_path=output_path)
-    
+
     assert os.path.exists(output_path)
     with open(output_path, "r") as f:
         written_data = json.load(f)
     assert written_data == result
 
+
 def teardown_module():
     """Clean up test files"""
     for f in Path("tmp").glob("test_*.json"):
         f.unlink(missing_ok=True)
-    # Reset apollo_port to default
-    set_apollo_port(3000)


### PR DESCRIPTION
## Short Description

Refactor Python service entry point to use named arguments instead of positional arguments, making it easier to use, more maintainable, and less error-prone.

Fixes #132

## Implementation Details

The Python service entry point (`entry.py`) is a critical part of our system, used both at runtime by the API and during local development. Previously, it relied on positional arguments for service configuration, which caused confusion and made the script harder to maintain.

### Key Changes
1. **Switch to Named Arguments**  
   The script now uses named arguments via `argparse`, making it more explicit and self-explanatory:  
   
   ```bash
   python services/entry.py <service> --input input.json --output output.json --port 5000
   ```
   
   - `<service>`: Required; specifies the service to run.
   - `--input` (`-i`): Optional; path to the input JSON file.
   - `--output` (`-o`): Optional; path to the output JSON file (auto-generated if not provided).
   - `--port` (`-p`): Optional; sets the Apollo server port.

2. **Improved Error Handling**  
   - Clear error messages are provided for common issues like invalid JSON input or missing files.
   - Type hints have been added for better clarity and maintainability.

3. **Integration**  
   - `bridge.ts` has been updated to use the new named argument format when spawning Python processes.

These changes enhance the usability and maintainability of the entry point while maintaining backward compatibility for existing API.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
