### PR TITLE
Add api key status check

### DIFF
--- a/platform/src/middleware/healthcheck.tsx
+++ b/platform/src/middleware/healthcheck.tsx
@@ -1,9 +1,19 @@
 import { Elysia } from "elysia";
 import pkg from "../../../package.json" assert { type: "json" };
+import { run } from '../bridge';
 
 export default async (app: Elysia) => {
   app.get("/livez", () => {
     return new Response(JSON.stringify({ version: pkg.version }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  });
+  app.get("/status", async () => {
+    const status = await run ('status', 0, {} as any) as any;
+    return new Response(status, {
       status: 200,
       headers: {
         "Content-Type": "application/json",

--- a/services/status/README.md
+++ b/services/status/README.md
@@ -1,0 +1,11 @@
+# Status
+
+This a service that tests whether API keys are working. It check for Anthropic, OpenAI and Pinecone keys from the environment. It does not cost tokens to use.
+
+## Usage
+
+This service can be run from the services folder via the entry.py module. The input is an empty JSON:
+
+```bash
+python entry.py status --input tmp/input.json
+```

--- a/services/status/status.py
+++ b/services/status/status.py
@@ -1,0 +1,42 @@
+import os
+import json
+from openai import OpenAI
+from pinecone import Pinecone
+from anthropic import Anthropic
+from util import create_logger
+
+logger = create_logger("status")
+
+def test_openai_key(api_key):
+    try:
+        OpenAI(api_key=api_key).models.list()
+        return True
+    except Exception:
+        return False
+
+def test_pinecone_key(api_key):
+    try:
+        Pinecone(api_key=api_key).list_indexes()
+        return True
+    except Exception:
+        return False
+
+def test_anthropic_key(api_key):
+    try:
+        Anthropic(api_key=api_key).models.list()
+        return True
+    except Exception:
+        return False
+
+def main(data):
+    status = {
+        "openai": "working" if test_openai_key(os.getenv('OPENAI_API_KEY')) else "not working",
+        "pinecone": "working" if test_pinecone_key(os.getenv('PINECONE_API_KEY')) else "not working",
+        "anthropic": "working" if test_anthropic_key(os.getenv('ANTHROPIC_API_KEY')) else "not working"
+    }
+
+    logger.info(f"API Keys status: {json.dumps(status)}")
+    return json.dumps(status)
+
+if __name__ == "__main__":
+    print(main(None))


### PR DESCRIPTION
## Short Description

Add a status check for API keys

Fixes #162 

## Implementation Details

Checks if Anthropic, OpenAI and Pinecone keys are working. It does not cost tokens to run the status check.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
