### PR TITLE
update docsite embeddings automatically

### DIFF
--- a/services/embed_docsite/README.md
+++ b/services/embed_docsite/README.md
@@ -27,21 +27,14 @@ The service uses the DocsiteProcessor to download the documentation and chunk it
 The chunked texts can be viewed in `tmp/split_sections`.
 
 ## Payload Reference
-The input payload is a JSON object. A simple example with default values:
-
-```js
-{
-    "collection_name": "Docsite-20250225", // Name of the collection in the vector database.
-}
-```
-
-An example with all parameters:
+The input payload is a JSON object. All parameters are optional:
 
 ```js
 {
     "docs_to_upload": ["adaptor_docs", "general_docs", "adaptor_functions"], // Select from 3 types of documentation to upload
-    "collection_name": "Docsite-20250225", // Name of the collection in the vector database
-    "index_name": "Docsite", // Name of the index in the vector database (an index contains collections)
-    "docs_to_ignore": ["job-examples.md", "release-notes.md"],
+    "collection_name": "docsite-20250225", // Name of the collection in the vector database (defaults to the current date)
+    "index_name": "docsite", // Name of the index in the vector database (an index contains collections; defaults to docsite)
+    "docs_to_ignore": ["job-examples.md", "release-notes.md"], // Titles of documents that should not be indexed
+    "max_total_collections" : 3 // The max number of collections to keep in the vector database. This will delete older collections by date.
 }
 ```

--- a/services/embed_docsite/docsite_indexer.py
+++ b/services/embed_docsite/docsite_indexer.py
@@ -1,7 +1,6 @@
 import os
 import time
 from datetime import datetime
-import json
 import pandas as pd
 from pinecone import Pinecone, ServerlessSpec
 from langchain_pinecone import PineconeVectorStore
@@ -19,19 +18,21 @@ class DocsiteIndexer:
     :param index_name: Vectorstore index name (default: docsite)
     :param embeddings: LangChain embedding type (default: OpenAIEmbeddings())
     :param dimension: Embedding dimension (default: 1536 for OpenAI Embeddings)
+    :param max_total_collections: Max total collections in index. Delete old collections by date if exceeded after a new upload (default: 50)
     """
-    def __init__(self, collection_name, index_name="docsite", embeddings=OpenAIEmbeddings(), dimension=1536):
-        self.collection_name = collection_name
+    def __init__(self, collection_name=None, index_name="docsite", embeddings=OpenAIEmbeddings(), dimension=1536, max_total_collections=50):
+        self.collection_name = collection_name if collection_name is not None else f"docsite-{datetime.now().strftime('%Y%m%d%H%M')}"
         self.index_name = index_name
         self.embeddings = embeddings
         self.dimension = dimension
+        self.max_total_collections = max_total_collections
         self.pc = Pinecone(api_key=os.environ.get("PINECONE_API_KEY"))
 
         if not self.index_exists():
             self.create_index()
 
         self.index = self.pc.Index(self.index_name)
-        self.vectorstore = PineconeVectorStore(index_name=index_name, namespace=collection_name, embedding=embeddings)
+        self.vectorstore = PineconeVectorStore(index_name=index_name, namespace=self.collection_name, embedding=embeddings)
 
     def insert_documents(self, inputs, metadata_dict):
         """
@@ -86,19 +87,20 @@ class DocsiteIndexer:
         
         if vectors_after <= vectors_before:
             logger.warning(f"Could not verify full dataset upload to namespace '{self.collection_name}' after {max_wait_time}s")
-    
+
+        self.delete_old_collections(self.max_total_collections)
+
         return idx
 
     def delete_collection(self):
         """
         Deletes the entire collection (namespace) and all its contents.
-        This operation cannot be undone and removes both the collection structure
-        and all vectors/documents within it.
+        This operation cannot be undone and removes both the collection structure and all vectors/documents within it.
         """
         self.index.delete(delete_all=True, namespace=self.collection_name)
 
-    def delete_old_collections(self, max_collections=3):
-            """Retrieve the oldest docsite uploads by collection name from Pinecone and delete them."""
+    def delete_old_collections(self, max_total_collections):
+            """Retrieve docsite uploads by collection name from Pinecone and delete them if there are more than max_total_collections."""
             
             logger.info(f"Fetching outdated docsite collections")
             pc = Pinecone(api_key=os.environ.get("PINECONE_API_KEY"))
@@ -109,17 +111,14 @@ class DocsiteIndexer:
                 (ns for ns in namespaces if ns.startswith("docsite-") and ns[8:].isdigit() and len(ns) == 16),
                 reverse=False
             )
-            if len(valid_namespaces) > max_collections:
+            if len(valid_namespaces) > max_total_collections:
                 logger.info(f"Deleting outdated docsite collections")
-                for old_collection in valid_namespaces[:max_collections]:
+                for old_collection in valid_namespaces[:max_total_collections]:
                     self.index.delete(delete_all=True, namespace=old_collection)
                     logger.info(f"Deleted collection {old_collection}")
 
             if not valid_namespaces:
                 logger.info(f"No valid namespaces found in the index when deleting old collections.")
-
-            most_recent_uploads = valid_namespaces[max_collections:]
-            logger.info(f"Most recent docsite collections remaining in index: {most_recent_uploads}")
 
     def create_index(self):
         """Creates a new Pinecone index if it does not exist."""

--- a/services/embed_docsite/embed_docsite.py
+++ b/services/embed_docsite/embed_docsite.py
@@ -1,6 +1,4 @@
 import os
-import time
-from datetime import datetime
 import json
 from dotenv import load_dotenv
 import pandas as pd
@@ -13,20 +11,17 @@ logger = create_logger("embed_docsite")
 def main(data):
     logger.info("Starting...")
 
-    # Parse payload
-    collection_name = data.get("collection_name") or f"docsite-{datetime.now().strftime('%Y%m%d%H%M')}"
-
     # Get selection of doc types to upload, or default to all
     docs_to_upload = data.get("docs_to_upload", ["adaptor_docs", "general_docs", "adaptor_functions"])
     docs_to_ignore = data.get("docs_to_ignore", ["job-examples.md", "release-notes.md"])
 
     # Get other fields
-    other_params = {}
-    other_param_options = ["index_name"]
+    index_params = {}
+    index_param_options = ["collection_name", "index_name", "max_total_collections"]
 
-    for key in other_param_options:
+    for key in index_param_options:
         if key in data:
-            other_params[key] = data[key]
+            index_params[key] = data[key]
 
     # Set API keys
     load_dotenv(override=True)
@@ -55,7 +50,7 @@ def main(data):
         raise ApolloError(500, f'Missing API keys: {", ".join(missing_keys)}. Add to payload or environment.', type="BAD_REQUEST")
 
     # Initialize indexer
-    docsite_indexer = DocsiteIndexer(collection_name=collection_name, **other_params)
+    docsite_indexer = DocsiteIndexer(**(index_params or {}))
 
     # Add docs
     for docs_type in docs_to_upload:

--- a/services/embed_docsite/embed_docsite.py
+++ b/services/embed_docsite/embed_docsite.py
@@ -14,15 +14,7 @@ def main(data):
     logger.info("Starting...")
 
     # Parse payload
-    # Get required fields
-    required_fields = ["collection_name"]
-    missing = [field for field in required_fields if field not in data]
-    
-    if missing:
-        logger.error(f"Missing required fields in data: {', '.join(missing)}")
-        return
-    
-    collection_name = data["collection_name"]
+    collection_name = data.get("collection_name") or f"docsite-{datetime.now().strftime('%Y%m%d%H%M')}"
 
     # Get selection of doc types to upload, or default to all
     docs_to_upload = data.get("docs_to_upload", ["adaptor_docs", "general_docs", "adaptor_functions"])


### PR DESCRIPTION
## Short Description
Add
a) github action to update apollo embeddings when docsite is updated
b) Add a step to enable using the latest collection by default

Fixes #173

## Implementation Details

a) Adjust docsite upload functionalities for automated updates (to be set in GitHub actions)
- change docsite naming convention to have more precise time (YYYYMMDDhhmm) in case there are multiple docsite udpates in a day
- add max_total_collections parameter to delete oldest collection if there's more than n collections with the name format "docsite-YYYYMMDD" (ignore other collections e.g. "docsite-test")

b) Accessing the latest collection:
Adds a step in the Search Docsite service to get the names of collections within an index, and use the collection with the latest date, unless a specific collection is not requested. This is done in  `_get_most_recent_namespace` in `DocsiteSearch`. 
When called from the AI assistant, this would run every time we query the database (once at the beginning of a conversation).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
