### PR TITLE
Fix job chat bug requiring Anthropic API key in env

### DIFF
--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -72,7 +72,13 @@ class AnthropicClient:
         """
         history = history.copy() if history else []
 
-        system_message, prompt, retrieved_knowledge = build_prompt(content, history, context, rag)
+        system_message, prompt, retrieved_knowledge = build_prompt(
+            content=content, 
+            history=history, 
+            context=context, 
+            rag=rag, 
+            api_key=self.api_key
+            )
 
         message = self.client.messages.create(
             max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -146,7 +146,7 @@ class Context:
 
 
 def generate_system_message(context_dict, search_results):
-    context = context_dict if isinstance(context_dict, Context) else Context(**context_dict)
+    context = context_dict if isinstance(context_dict, Context) else Context(**(context_dict or {}))
 
     message = [system_role]
     message.append(f"<job_writing_guide>{job_writing_summary}</job_writing_guide>")

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -196,7 +196,7 @@ def format_search_results(search_results):
         for result in search_results
     ])
 
-def build_prompt(content, history, context, rag=None):
+def build_prompt(content, history, context, rag=None, api_key=None):
     retrieved_knowledge = {
         "search_results": [],
         "search_results_sections": [],
@@ -217,7 +217,8 @@ def build_prompt(content, history, context, rag=None):
               content=content, 
               history=history, 
               code=context.get("expression", ""), 
-              adaptor=context.get("adaptor", "")
+              adaptor=context.get("adaptor", ""),
+              api_key=api_key
           )
       except Exception as e:
           logger.error(f"Error retrieving knowledge: {str(e)}")


### PR DESCRIPTION
## Short Description

Fixes a bug in the job_chat service RAG module which requires the Anthropic API key to be set in the environment, instead of optionally using the API key given in the payload.

## Implementation Details

The job_chat service, including the RAG module within it, can now correctly take the Anthropic API key from the input JSON. It reverts to the env API key if the API key is not given in the input.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
