### PR TITLE
Workflow generation prompt updates

### DIFF
--- a/.changeset/short-owls-rescue.md
+++ b/.changeset/short-owls-rescue.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+improve prompt for workflow generation

--- a/.changeset/short-owls-rescue.md
+++ b/.changeset/short-owls-rescue.md
@@ -1,5 +1,0 @@
----
-"apollo": patch
----
-
-improve prompt for workflow generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # apollo
 
+## 0.11.4
+
+### Patch Changes
+
+- bdc0daf: improve prompt for workflow generation
+
 ## 0.11.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/services/workflow_chat/gen_project_config.yaml
+++ b/services/workflow_chat/gen_project_config.yaml
@@ -4,4 +4,4 @@ llm_retrieval: "claude-3-7-sonnet-20250219"
 threshold: 0.7
 top_k: 5
 temperature: 0
-prompts_version: 1.0
+prompts_version: 1.2.0

--- a/services/workflow_chat/gen_project_prompt.py
+++ b/services/workflow_chat/gen_project_prompt.py
@@ -1,3 +1,4 @@
+
 import os
 from .config_loader import ConfigLoader
 from .available_adaptors import available_adaptors
@@ -19,8 +20,12 @@ def chat_prompt(content, existing_yaml, history):
     else:
         existing_yaml = "\nFor context, the user is currently editing this YAML:\n" + existing_yaml
     
-    system_message = config_loader.get_prompt("get_info_gen_yaml_system_prompt")
-    system_message = system_message.format(adaptors = adaptors_string)
+    system_message = config_loader.get_prompt("main_system_prompt")
+    system_message = system_message.format(
+        adaptors=adaptors_string, 
+        mode_specific_intro=config_loader.get_prompt("normal_mode_intro"),
+        mode_specific_instructions=config_loader.get_prompt("normal_mode_instructions")
+    )
     system_message += existing_yaml
 
     prompt = []
@@ -38,8 +43,12 @@ def error_prompt(content, existing_yaml, errors, history):
     if not content:
         content = ""
     
-    system_message = config_loader.get_prompt("fix_yaml_error_system_prompt")
-    system_message = system_message.format(adaptors = adaptors_string)
+    system_message = config_loader.get_prompt("main_system_prompt")
+    system_message = system_message.format(
+        adaptors=adaptors_string,
+        mode_specific_intro=config_loader.get_prompt("error_mode_intro"), 
+        mode_specific_instructions=config_loader.get_prompt("error_mode_instructions")
+    )
     system_message += existing_yaml
     content += "\nThis is the error message:\n" + errors
     

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -1,14 +1,8 @@
-prompts_version: 1.0
+prompts_version: 1.2.0
 prompts:
-  get_info_gen_yaml_system_prompt: |
+  main_system_prompt: |
     You are an expert assistant for the OpenFn workflow automation platform.
-    Your task is to talk to a client with the goal of converting their description of a workflow into an OpenFn workflow YAML.
-    You should produce properly structured YAML files that define workflow jobs, triggers, and connections.
-    This might be an iterative process, where you adjust a previous YAML according to the user's instructions.
-    If necessary, you can ask the user for clarification instead of producing a YAML. You should ask for more details if it is not possible to determine what kind of data and databases/services they are using.
-    Do not produce a YAML unnecessarily; if the user does not otherwise appear to want a new YAML (and is instead e.g. asking for a clarification or hit send too early),
-    do not produce a YAML in your answer.
-    Be as brief as possible in your answers.
+    {mode_specific_intro}
 
     ## Your Task
 
@@ -100,6 +94,25 @@ prompts:
     You must respond in JSON format with two fields: "text" and "yaml". 
     "text" for all explanation, and "yaml" for the YAML block.
 
+    {mode_specific_instructions}
+
+  normal_mode_intro: |
+    Your task is to talk to a client with the goal of converting their description of a workflow into an OpenFn workflow YAML.
+    You should produce properly structured YAML files that define workflow jobs, triggers, and connections.
+    This might be an iterative process, where you adjust a previous YAML according to the user's instructions.
+    If necessary, you can ask the user for clarification instead of producing a YAML. You should ask for more details if it is not possible to determine what kind of data and databases/services they are using.
+    Do not produce a YAML unnecessarily; if the user does not otherwise appear to want a new YAML (and is instead e.g. asking for a clarification or hit send too early),
+    do not produce a YAML in your answer.
+    Be as brief as possible in your answers.
+  
+  error_mode_intro: |
+    You are talking to a client with the goal of converting their description of a workflow into an OpenFn workflow YAML.
+    Your previous suggestion produced an invalid OpenFn worfkflow YAML. You will receive the error message below to revise your answer.
+    Your task is to produce a corrected, properly structured OpenFn workflow YAML that defines workflow jobs (steps), triggers (webhook or cron),
+    and connections (edges) and references the appropriate adaptors with their exact names.
+    Explain your correction, and be as brief as possible in your answers.
+
+  normal_mode_instructions: |
     You can either
     A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as null,
 
@@ -113,97 +126,7 @@ prompts:
 
     The user's latest message and prior conversation are provided below. Generate your response accordingly.
 
-  fix_yaml_error_system_prompt: |
-    You are an expert assistant for the OpenFn workflow automation platform.
-    You are talking to a client with the goal of converting their description of a workflow into an OpenFn workflow YAML.
-    Your previous suggestion produced an invalid OpenFn worfkflow YAML. You will receive the error message below to revise your answer.
-    Your task is to produce a corrected, properly structured OpenFn workflow YAML that defines workflow jobs (steps), triggers (webhook or cron),
-    and connections (edges) and references the appropriate adaptors with their exact names.
-    Explain your correction, and be as brief as possible in your answers.
-
-    ## OpenFn Project.yaml Structure
-
-    A valid project.yaml must follow this structure:
-    ```
-    name: open-project
-    jobs:
-      job-one:
-        name: First Job
-        adaptor: "@openfn/language-common@latest"
-        body: "// Add operations here"
-      job-two:
-        name: Second Job
-        adaptor: "@openfn/language-http@latest"
-        body: "// Add operations here"
-    triggers:
-      # Choose one trigger type and remove the other
-      cron:  # For scheduled jobs
-        type: cron
-        cron_expression: 0 0 * * *  # Format: minute hour day month weekday
-        enabled: false
-      # OR
-      webhook:  # For event-based jobs
-        type: webhook
-        enabled: false
-    edges:
-      daily-trigger->job-one:
-        source_trigger: daily-trigger
-        target_job: job-one
-        condition_type: always
-        enabled: true
-      job-one->job-two:
-        source_job: job-one
-        target_job: job-two
-        condition_type: on_job_success
-        enabled: true
-    ```
-
-    ## Adaptor Knowledge
-
-    Here is a list of available OpenFn adaptors:
-    {adaptors}
-    ## Trigger Types
-
-    - **Webhook**: Use for event-based triggers (default if not specified)
-    - **Cron**: Use for time-based schedules
-    The trigger should be set to enabled: false by default.
-
-    ## Rules for Job Identification
-
-    1. Each distinct action should become its own job
-    2. Jobs should have clear, descriptive names
-    3. Jobs should be connected in a logical sequence
-    4. Choose the most specific adaptor available for each operation
-    5. When in doubt about an adaptor, use `@openfn/language-common@latest`
-    6. Job IDs should be derived from their names, replacing spaces with hyphens
-
-    ## Rules for Edge Creation
-
-    1. The first job should always connect to the trigger
-    2. Each subsequent job should connect to the previous job with one condition_type: on_job_success, on_job_failure, always or js_expression (for the latter, also add a condition_expression in quotes e.g. "!state.error")
-    3. For branching workflows, create conditional edges as appropriate
-    4. Edges should be enabled by default
-
-    ## Example Conversation
-
-    User's conversation turn:
-    "Fetch visits from commare once a day. For each visitor with an IHS number, create a FHIR Encounter in Satusehat. Otherwise, lookup the number in satusehat and then create an encounter"
-
-    The output should be:
-    {{
-      "text": "Your reasoning (max ~4 sentences).",
-      "yaml": "name: Daily CommCare to Satusehat Encounter Sync\njobs:\n  Fetch-visits-from-CommCare:\n    name: Fetch visits from CommCare\n    adaptor: \"@openfn/language-commcare@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    name: Create FHIR Encounter for visitors with IHS number\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Lookup-IHS-number-in-Satusehat:\n    name: Lookup IHS number in Satusehat\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-after-IHS-lookup:\n    name: Create FHIR Encounter after IHS lookup\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\ntriggers:\n  cron:\n    type: cron\n    cron_expression: 0 0 * * *\n    enabled: false\nedges:\n  cron->Fetch-visits-from-CommCare:\n    source_trigger: cron\n    target_job: Fetch-visits-from-CommCare\n    condition_type: always\n    enabled: true\n  Fetch-visits-from-CommCare->Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Create-FHIR-Encounter-for-visitors-with-IHS-number\n    condition_type: on_job_success\n    enabled: true\n  Fetch-visits-from-CommCare->Lookup-IHS-number-in-Satusehat:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Lookup-IHS-number-in-Satusehat\n    condition_type: on_job_success\n    enabled: true\n  Lookup-IHS-number-in-Satusehat->Create-FHIR-Encounter-after-IHS-lookup:\n    source_job: Lookup-IHS-number-in-Satusehat\n    target_job: Create-FHIR-Encounter-after-IHS-lookup\n    condition_type: on_job_success\n    enabled: true"
-    }}
-
-    ## Do NOT fill in job code
-    Your task is to create the workflow structure only — do NOT generate job code (i.e., the "body" key in jobs). 
-    If the user asks for job code, DECLINE to provide it, and inform them that they can fill it in after approving the workflow structure and optionally consult the AI Assistant in the Workflow Inspector.
-
-    ## Output Format
-
-    You must respond in JSON format with two fields: "text" and "yaml". 
-    "text" for all explanation, and "yaml" for the YAML block.
-
+  error_mode_instructions: |
     Answer with BOTH the "text" key and the "yaml" key.
     You should provide a few sentences in the "text" key (max. as many sentences as there are jobs in the workflow) to explain your reasoning
     about the error and your correction.

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -15,7 +15,7 @@ prompts:
     Given a text description of a workflow process, you will:
     1. Identify distinct jobs/steps in the workflow. You should ALWAYS leave the job code in the "body" key for jobs empty and refuse to generate it (you can tell the user to get help from AI Assistant in the Workflow Inspector after approving the workflow structure).
     2. Determine appropriate adaptors for each job
-    3. Set up proper trigger mechanisms (webhook or cron)
+    3. Set up proper trigger mechanisms (webhook or cron). Note that ONLY ONE node/job can come from the trigger.
     4. Create the connections (edges) between jobs
     5. Generate a valid project.yaml file that follows OpenFn's structure
 
@@ -77,7 +77,7 @@ prompts:
 
     ## Rules for Edge Creation
 
-    1. The first job should always connect to the trigger
+    1. The first job should always connect to the trigger, and the trigger can only connect to ONE job. If the user wants multiple things to happen in parallel in the first step, you should pick one of them to happen first.
     2. Each subsequent job should connect to the previous job with one condition_type: on_job_success, on_job_failure, always or js_expression (for the latter, also add a condition_expression in quotes e.g. "!state.error")
     3. For branching workflows, create conditional edges as appropriate
     4. Edges should be enabled by default

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -69,7 +69,7 @@ prompts:
     ## Rules for Job Identification
 
     1. Each distinct action should become its own job
-    2. Jobs should have clear, descriptive names
+    2. Jobs should have clear, descriptive names. Job names cannot have special characters and must be under 100 characters.
     3. Jobs should be connected in a logical sequence
     4. Choose the most specific adaptor available for each operation
     5. When in doubt about an adaptor, use `@openfn/language-common@latest` for data transformation and `@openfn/language-http@latest` for platform integrations.

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -19,6 +19,8 @@ prompts:
     4. Create the connections (edges) between jobs
     5. Generate a valid project.yaml file that follows OpenFn's structure
 
+    When describing your overall purpose to the user, use simple language and explain your task is to help them create an OpenFn workflow. Avoid mentioning YAMLs, as the user does not see the YAML, but a chart drawn based on it.
+
     ## OpenFn Project.yaml Structure
 
     A valid project.yaml must follow this structure:

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -165,8 +165,6 @@ class AnthropicClient:
             output_yaml = response_data.get("yaml", "")
 
             if output_yaml and output_yaml.strip():
-                # Decode the escaped newlines into actual newlines if needed
-                # output_yaml = output_yaml.encode().decode("unicode_escape")
                 # Parse YAML string into Python object
                 output_yaml = yaml.safe_load(output_yaml)
                 # Log if using invalid adaptors


### PR DESCRIPTION
## Short Description

Adjust the prompt in the workflow generation service to:

- Specify that triggers can only have one node out of them. The LLM will pick one task to schedule first if the user asks for multiple simultaneous tasks. Fixes [#3307](https://github.com/OpenFn/lightning/issues/3307)
- Specify the rules for job names. Also adds rule-based cleaning of special characters and diacritics. Fixes  #244 
- Tell the model to use simpler language, fixes #239
- Merge the two types of prompts  (errors, other conversational turns) to make it easier to edit

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
