### PR TITLE
Raise the job_chat output token limit

### DIFF
--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -44,7 +44,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = "claude-3-7-sonnet-20250219"
-    max_tokens: int = 1024
+    max_tokens: int = 16384
     api_key: Optional[str] = None
 
 

--- a/services/job_chat/retrieve_docs.py
+++ b/services/job_chat/retrieve_docs.py
@@ -146,7 +146,7 @@ def call_llm(model, temperature, system_prompt, user_prompt, client):
     """Helper method to make LLM calls."""
     message = client.messages.create(
         model=model,
-        max_tokens=500,
+        max_tokens=1024,
         temperature=temperature,
         system=system_prompt,
         messages=[


### PR DESCRIPTION
## Short Description

The general AI Assistant has an output token limit that is too low. This could be causing issues when dealing with longer code.

Setting the limit higher does not mean answers will be longer on average.

The main change is in the chat output tokens, but I upped the RAG calls just in case.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
