### PR TITLE
workflow_gen: Add UUID preservation to workflow generation

### DIFF
--- a/.changeset/smart-rats-shake.md
+++ b/.changeset/smart-rats-shake.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+workflow_chat: preserve UUIDs during workflow generation

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -22,10 +22,12 @@ prompts:
     name: open-project
     jobs:
       job-one:
+        id: {{ID_JOB_job-one}}
         name: First Job
         adaptor: "@openfn/language-common@latest"
         body: "// Add operations here"
       job-two:
+        id: {{ID_JOB_job-two}}
         name: Second Job
         adaptor: "@openfn/language-http@latest"
         body: "// Add operations here"
@@ -41,11 +43,13 @@ prompts:
         enabled: false
     edges:
       daily-trigger->job-one:
+        id: {{ID_EDGE_daily-trigger->job-one}}
         source_trigger: daily-trigger
         target_job: job-one
         condition_type: always
         enabled: true
       job-one->job-two:
+        id: {{ID_EDGE_job-one->job-two}}
         source_job: job-one
         target_job: job-two
         condition_type: on_job_success
@@ -53,10 +57,11 @@ prompts:
     ```
 
     ## Editing existing workflows:
-    Job bodies may contain code placeholders like `__CODE_BLOCK_jobname_v1__`. These represent existing code that should be preserved unchanged.
-    NEVER modify, remove, or replace these placeholders.
-    When creating new jobs, use the standard `"// Add operations here"` placeholder.
-    You can rename jobs freely - the code will be preserved based on the job ID.
+    When editing existing workflows, you may see placeholders for IDs like {{ID_JOB_jobname}} or {{ID_EDGE_jobname}} in the YAML. These represent unique IDs for jobs and edges.
+    You may also see placeholders for code blocks like "__CODE_BLOCK_jobname__". These represent existing code.
+    You must retain these placeholders EXACTLY as they appear (even if the job/edge name has changed) in the appropriate locations, so that the existing IDs and code can be added back in using string replacement later.
+    You can rename jobs freely — code and IDs will be preserved using their respective placeholders, which you must not alter.
+    When creating new jobs, use the standard `"// Add operations here"` placeholder for job code. You do not need to add an ID field for new jobs/edges, as these will be generated automatically.
 
     ## Adaptor Knowledge
 

--- a/services/workflow_chat/tests/test_functions.py
+++ b/services/workflow_chat/tests/test_functions.py
@@ -17,13 +17,13 @@ def test_extract_job_codes_preserves_real_code(client):
         }
     }
     
-    preserved_codes, preserved_ids, processed_yaml = client.extract_and_preserve_components(yaml_data)
+    preserved_values, processed_yaml = client.extract_and_preserve_components(yaml_data)
     
-    assert len(preserved_codes) == 2
-    assert preserved_codes["job1"]["code"] == "console.log('hello world')"
-    assert preserved_codes["job2"]["code"] == "const data = fetchData();\nprocessData(data);"
-    assert preserved_codes["job1"]["placeholder"] == "__CODE_BLOCK_job1__"
-    assert preserved_codes["job2"]["placeholder"] == "__CODE_BLOCK_job2__"
+    assert len(preserved_values) == 2
+    assert preserved_values["job_body_job1"]["value"] == "console.log('hello world')"
+    assert preserved_values["job_body_job2"]["value"] == "const data = fetchData();\nprocessData(data);"
+    assert preserved_values["job_body_job1"]["placeholder"] == "__CODE_BLOCK_job1__"
+    assert preserved_values["job_body_job2"]["placeholder"] == "__CODE_BLOCK_job2__"
 
 
 def test_extract_job_codes_ignores_default_placeholder(client):
@@ -37,12 +37,12 @@ def test_extract_job_codes_ignores_default_placeholder(client):
         }
     }
     
-    preserved_codes, preserved_ids, processed_yaml = client.extract_and_preserve_components(yaml_data)
+    preserved_values, processed_yaml = client.extract_and_preserve_components(yaml_data)
     
-    assert len(preserved_codes) == 1
-    assert "job1" not in preserved_codes
-    assert "job3" not in preserved_codes
-    assert preserved_codes["job2"]["code"] == "real code here"
+    assert len(preserved_values) == 1
+    assert "job_body_job1" not in preserved_values
+    assert "job_body_job3" not in preserved_values
+    assert preserved_values["job_body_job2"]["value"] == "real code here"
 
 
 def test_sanitize_job_names_removes_diacritics(client):

--- a/services/workflow_chat/tests/test_functions.py
+++ b/services/workflow_chat/tests/test_functions.py
@@ -17,13 +17,13 @@ def test_extract_job_codes_preserves_real_code(client):
         }
     }
     
-    result = client.extract_job_codes(yaml_data)
+    preserved_codes, preserved_ids, processed_yaml = client.extract_and_preserve_components(yaml_data)
     
-    assert len(result) == 2
-    assert result["job1"]["code"] == "console.log('hello world')"
-    assert result["job2"]["code"] == "const data = fetchData();\nprocessData(data);"
-    assert result["job1"]["placeholder"] == "__CODE_BLOCK_job1__"
-    assert result["job2"]["placeholder"] == "__CODE_BLOCK_job2__"
+    assert len(preserved_codes) == 2
+    assert preserved_codes["job1"]["code"] == "console.log('hello world')"
+    assert preserved_codes["job2"]["code"] == "const data = fetchData();\nprocessData(data);"
+    assert preserved_codes["job1"]["placeholder"] == "__CODE_BLOCK_job1__"
+    assert preserved_codes["job2"]["placeholder"] == "__CODE_BLOCK_job2__"
 
 
 def test_extract_job_codes_ignores_default_placeholder(client):
@@ -37,12 +37,12 @@ def test_extract_job_codes_ignores_default_placeholder(client):
         }
     }
     
-    result = client.extract_job_codes(yaml_data)
+    preserved_codes, preserved_ids, processed_yaml = client.extract_and_preserve_components(yaml_data)
     
-    assert len(result) == 1
-    assert "job1" not in result
-    assert "job3" not in result
-    assert result["job2"]["code"] == "real code here"
+    assert len(preserved_codes) == 1
+    assert "job1" not in preserved_codes
+    assert "job3" not in preserved_codes
+    assert preserved_codes["job2"]["code"] == "real code here"
 
 
 def test_sanitize_job_names_removes_diacritics(client):

--- a/services/workflow_chat/tests/test_functions.py
+++ b/services/workflow_chat/tests/test_functions.py
@@ -20,10 +20,8 @@ def test_extract_job_codes_preserves_real_code(client):
     preserved_values, processed_yaml = client.extract_and_preserve_components(yaml_data)
     
     assert len(preserved_values) == 2
-    assert preserved_values["job_body_job1"]["value"] == "console.log('hello world')"
-    assert preserved_values["job_body_job2"]["value"] == "const data = fetchData();\nprocessData(data);"
-    assert preserved_values["job_body_job1"]["placeholder"] == "__CODE_BLOCK_job1__"
-    assert preserved_values["job_body_job2"]["placeholder"] == "__CODE_BLOCK_job2__"
+    assert preserved_values["__CODE_BLOCK_job1__"] == "console.log('hello world')"
+    assert preserved_values["__CODE_BLOCK_job2__"] == "const data = fetchData();\nprocessData(data);"
 
 
 def test_extract_job_codes_ignores_default_placeholder(client):
@@ -40,9 +38,9 @@ def test_extract_job_codes_ignores_default_placeholder(client):
     preserved_values, processed_yaml = client.extract_and_preserve_components(yaml_data)
     
     assert len(preserved_values) == 1
-    assert "job_body_job1" not in preserved_values
-    assert "job_body_job3" not in preserved_values
-    assert preserved_values["job_body_job2"]["value"] == "real code here"
+    assert "__CODE_BLOCK_job1__" not in preserved_values
+    assert "__CODE_BLOCK_job3__" not in preserved_values
+    assert preserved_values["__CODE_BLOCK_job2__"] == "real code here"
 
 
 def test_sanitize_job_names_removes_diacritics(client):

--- a/services/workflow_chat/tests/test_pass_fail.py
+++ b/services/workflow_chat/tests/test_pass_fail.py
@@ -16,24 +16,29 @@ def test_change_trigger():
 name: fridge-statistics-processing
 jobs:
   parse-and-aggregate-fridge-data:
+    id: job-parse-id
     name: Parse and Aggregate Fridge Data
     adaptor: '@openfn/language-common@latest'
     body: 'print("hello a")'
   upload-to-redis:
+    id: job-upload-id
     name: Upload to Redis Collection
     adaptor: '@openfn/language-redis@latest'
     body: 'print("hello b")'
 triggers:
   webhook:
+    id: trigger-webhook-id
     type: webhook
     enabled: false
 edges:
   webhook->parse-and-aggregate-fridge-data:
+    id: edge-webhook-parse-id
     source_trigger: webhook
     target_job: parse-and-aggregate-fridge-data
     condition_type: always
     enabled: true
   parse-and-aggregate-fridge-data->upload-to-redis:
+    id: edge-parse-upload-id
     source_job: parse-and-aggregate-fridge-data
     target_job: upload-to-redis
     condition_type: on_job_success

--- a/services/workflow_chat/tests/test_qualitative.py
+++ b/services/workflow_chat/tests/test_qualitative.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import subprocess
 from pathlib import Path
-from .test_utils import call_workflow_chat_service, make_service_input, print_response_details, assert_yaml_section_contains_all
+from .test_utils import call_workflow_chat_service, make_service_input, print_response_details, assert_yaml_section_contains_all, assert_yaml_has_ids, assert_yaml_jobs_have_body
 import yaml
 
 # ---- TESTS ----
@@ -23,6 +23,10 @@ def test_basic_input():
 
     assert response is not None
     assert isinstance(response, dict)
+    # Check for id fields in generated YAML
+    if response.get("response_yaml"):
+        assert_yaml_has_ids(response["response_yaml"], context="test_basic_input")
+        assert_yaml_jobs_have_body(response["response_yaml"], context="test_basic_input")
 
 def test_input_second_turn():
     print("Description: Simple second conversation turn requesting a change to the YAML")
@@ -175,6 +179,10 @@ def test_special_characters():
     print_response_details(response, "empty_water_bug", content=content)
     assert response is not None
     assert isinstance(response, dict)
+    # Check for id fields in generated YAML
+    if response.get("response_yaml"):
+        assert_yaml_has_ids(response["response_yaml"], context="test_special_characters")
+        assert_yaml_jobs_have_body(response["response_yaml"], context="test_special_characters")
 
 def test_simple_lang_bug():
     print("==================TEST==================")
@@ -191,6 +199,10 @@ def test_simple_lang_bug():
     response_text = response.get("response", "")
 
     assert "yaml" not in response_text.lower(), f"Response text should not mention 'YAML', but got: {response_text}"
+    # Check for id fields in generated YAML
+    if response.get("response_yaml"):
+        assert_yaml_has_ids(response["response_yaml"], context="test_simple_lang_bug")
+        assert_yaml_jobs_have_body(response["response_yaml"], context="test_simple_lang_bug")
 
 def test_single_trigger_node():
     print("==================TEST==================")

--- a/services/workflow_chat/tests/test_qualitative.py
+++ b/services/workflow_chat/tests/test_qualitative.py
@@ -31,42 +31,51 @@ def test_input_second_turn():
 name: CommCare-to-DHIS2-Patient-Integration
 jobs:
   receive-commcare-data:
+    id: job-receive-id
     name: Receive CommCare Patient Data
     adaptor: '@openfn/language-commcare@latest'
     body: 'PLACEHOLDER 1'
   validate-patient-data:
+    id: job-validate-id
     name: Validate Patient Data
     adaptor: '@openfn/language-common@latest'
     body: 'PLACEHOLDER 2'
   log-validation-errors:
+    id: job-log-id
     name: Log Validation Errors to Google Sheets
     adaptor: '@openfn/language-googlesheets@latest'
     body: 'PLACEHOLDER 3'
   transform-and-upload-to-dhis2:
+    id: job-transform-id
     name: Transform and Upload to DHIS2
     adaptor: '@openfn/language-dhis2@latest'
     body: 'PLACEHOLER 4'
 triggers:
   webhook:
+    id: trigger-webhook-id
     type: webhook
     enabled: false
 edges:
   webhook->receive-commcare-data:
+    id: edge-webhook-receive-id
     source_trigger: webhook
     target_job: receive-commcare-data
     condition_type: always
     enabled: true
   receive-commcare-data->validate-patient-data:
+    id: edge-receive-validate-id
     source_job: receive-commcare-data
     target_job: validate-patient-data
     condition_type: on_job_success
     enabled: true
   validate-patient-data->log-validation-errors:
+    id: edge-validate-log-id
     source_job: validate-patient-data
     target_job: log-validation-errors
     condition_type: on_job_failure
     enabled: true
   validate-patient-data->transform-and-upload-to-dhis2:
+    id: edge-validate-transform-id
     source_job: validate-patient-data
     target_job: transform-and-upload-to-dhis2
     condition_type: on_job_success
@@ -104,24 +113,29 @@ def test_conversational_turn():
 name: fridge-statistics-processing
 jobs:
   parse-and-aggregate-fridge-data:
+    id: job-parse-id
     name: Parse and Aggregate Fridge Data
     adaptor: '@openfn/language-common@latest'
     body: '| // Add data parsing and aggregation operations here'
   upload-to-redis:
+    id: job-upload-id
     name: Upload to Redis Collection
     adaptor: '@openfn/language-redis@latest'
     body: '| // Add Redis collection upload operations here'
 triggers:
   webhook:
+    id: trigger-webhook-id
     type: webhook
     enabled: false
 edges:
   webhook->parse-and-aggregate-fridge-data:
+    id: edge-webhook-parse-id
     source_trigger: webhook
     target_job: parse-and-aggregate-fridge-data
     condition_type: always
     enabled: true
   parse-and-aggregate-fridge-data->upload-to-redis:
+    id: edge-parse-upload-id
     source_job: parse-and-aggregate-fridge-data
     target_job: upload-to-redis
     condition_type: on_job_success
@@ -187,24 +201,29 @@ def test_single_trigger_node():
 name: fridge-statistics-processing
 jobs:
   parse-and-aggregate-fridge-data:
+    id: job-parse-id
     name: Parse and Aggregate Fridge Data
     adaptor: '@openfn/language-common@latest'
     body: 'print("hello a")'
   upload-to-redis:
+    id: job-upload-id
     name: Upload to Redis Collection
     adaptor: '@openfn/language-redis@latest'
     body: 'print("hello b")'
 triggers:
   webhook:
+    id: trigger-webhook-id
     type: webhook
     enabled: false
 edges:
   webhook->parse-and-aggregate-fridge-data:
+    id: edge-webhook-parse-id
     source_trigger: webhook
     target_job: parse-and-aggregate-fridge-data
     condition_type: always
     enabled: true
   parse-and-aggregate-fridge-data->upload-to-redis:
+    id: edge-parse-upload-id
     source_job: parse-and-aggregate-fridge-data
     target_job: upload-to-redis
     condition_type: on_job_success
@@ -230,24 +249,29 @@ def test_edit_job_code():
 name: fridge-statistics-processing
 jobs:
   parse-and-aggregate-fridge-data:
+    id: job-parse-id
     name: Parse and Aggregate Fridge Data
     adaptor: '@openfn/language-common@latest'
     body: 'print("hello a")'
   upload-to-redis:
+    id: job-upload-id
     name: Upload to Redis Collection
     adaptor: '@openfn/language-redis@latest'
     body: 'print("hello a")'
 triggers:
   webhook:
+    id: trigger-webhook-id
     type: webhook
     enabled: false
 edges:
   webhook->parse-and-aggregate-fridge-data:
+    id: edge-webhook-parse-id
     source_trigger: webhook
     target_job: parse-and-aggregate-fridge-data
     condition_type: always
     enabled: true
   parse-and-aggregate-fridge-data->upload-to-redis:
+    id: edge-parse-upload-id
     source_job: parse-and-aggregate-fridge-data
     target_job: upload-to-redis
     condition_type: on_job_success
@@ -273,24 +297,29 @@ def test_error_field():
 name: fridge-statistics-processing
 jobs:
   parse-and-aggregate-fridge-data:
+    id: job-parse-id
     name: Parse and Aggregate Fridge Data
     adaptor: '@openfn/language-commons@latest'
     body: '| // Add data parsing and aggregation operations here'
   upload-to-redis:
+    id: job-upload-id
     name: Upload to Redis Collection
     adaptor: '@openfn/language-redis@latest'
     body: '| // Add Redis collection upload operations here'
 triggers:
   webhook:
+    id: trigger-webhook-id
     type: webhook
     enabled: false
 edges:
   webhook->parse-and-aggregate-fridge-data:
+    id: edge-webhook-parse-id
     source_trigger: webhook
     target_job: parse-and-aggregate-fridge-data
     condition_type: always
     enabled: true
   parse-and-aggregate-fridge-data->upload-to-redis:
+    id: edge-parse-upload-id
     source_job: parse-and-aggregate-fridge-data
     target_job: upload-to-redis
     condition_type: on_job_success
@@ -318,87 +347,106 @@ def test_long_yaml():
 name: Data-Integration-and-Reporting
 jobs:
   Retrieve-Google-Sheets-Data:
+    id: job-retrieve-gsheets
     name: Retrieve Google Sheets Data
     adaptor: "@openfn/language-googlesheets@latest"
     body: // PLACEHOLDER 1
   Retrieve-NetSuite-Data:
+    id: job-retrieve-netsuite
     name: Retrieve NetSuite Data
     adaptor: "@openfn/language-http@latest"
     body: // PLACEHOLDER 2
   Retrieve-Ferntech-Data:
+    id: job-retrieve-ferntech
     name: Retrieve Ferntech Data
     adaptor: "@openfn/language-http@latest"
     body: // PLACEHOLDER 3
   Process-Combined-Data:
+    id: job-process-combined
     name: Process Combined Data
     adaptor: "@openfn/language-common@latest"
     body: // PLACEHOLDER 4
   Send-Email-Report:
+    id: job-send-email
     name: Send Email Report
     adaptor: "@openfn/language-gmail@latest"
     body: // PLACEHOLDER 5a
   write-to-sheet:
+    id: job-write-sheet
     name: write to sheet
     adaptor: "@openfn/language-googlesheets@3.0.13"
     body: // PLACEHOLDER 5b
   Summarise-with-claude:
+    id: job-summarise-claude
     name: Summarise with claude
     adaptor: "@openfn/language-claude@1.0.7"
     body: // PLACEHOLDER 5c
   Email-summary:
+    id: job-email-summary
     name: Email summary
     adaptor: "@openfn/language-gmail@1.3.0"
     body: // PLACEHOLDER 6
   Update-asana:
+    id: job-update-asana
     name: Update asana
     adaptor: "@openfn/language-asana@4.1.0"
     body: // PLACEHOLDER 7
 triggers:
   webhook:
+    id: trigger-webhook
     type: webhook
     enabled: false
 edges:
   webhook->Retrieve-Google-Sheets-Data:
+    id: edge-webhook-gsheets
     source_trigger: webhook
     target_job: Retrieve-Google-Sheets-Data
     condition_type: always
     enabled: true
   Retrieve-Google-Sheets-Data->Retrieve-NetSuite-Data:
+    id: edge-gsheets-netsuite
     source_job: Retrieve-Google-Sheets-Data
     target_job: Retrieve-NetSuite-Data
     condition_type: on_job_success
     enabled: true
   Retrieve-NetSuite-Data->Retrieve-Ferntech-Data:
+    id: edge-netsuite-ferntech
     source_job: Retrieve-NetSuite-Data
     target_job: Retrieve-Ferntech-Data
     condition_type: on_job_success
     enabled: true
   Retrieve-Ferntech-Data->Process-Combined-Data:
+    id: edge-ferntech-combined
     source_job: Retrieve-Ferntech-Data
     target_job: Process-Combined-Data
     condition_type: on_job_success
     enabled: true
   Process-Combined-Data->Send-Email-Report:
+    id: edge-combined-email
     source_job: Process-Combined-Data
     target_job: Send-Email-Report
     condition_type: on_job_success
     enabled: true
   Process-Combined-Data->write-to-sheet:
+    id: edge-combined-sheet
     source_job: Process-Combined-Data
     target_job: write-to-sheet
     condition_type: on_job_success
     enabled: true
   Process-Combined-Data->Summarise-with-claude:
+    id: edge-combined-summarise
     source_job: Process-Combined-Data
     target_job: Summarise-with-claude
     condition_type: on_job_success
     enabled: true
   Summarise-with-claude->Email-summary:
+    id: edge-summarise-email
     source_job: Summarise-with-claude
     target_job: Email-summary
     condition_type: on_job_success
     enabled: true
   Email-summary->Update-asana:
+    id: edge-email-asana
     source_job: Email-summary
     target_job: Update-asana
     condition_type: on_job_success

--- a/services/workflow_chat/tests/test_utils.py
+++ b/services/workflow_chat/tests/test_utils.py
@@ -166,3 +166,52 @@ def assert_yaml_section_contains_all(orig, new, section, context=''):
         assert new_section[key] == value, (
             f"{context}: Value for '{section}.{key}' changed.\nOriginal: {value}\nNew: {new_section[key]}"
         )
+
+
+def assert_yaml_has_ids(yaml_str_or_dict, context=''):
+    """
+    Assert that every job, trigger, and edge in the YAML has a non-empty 'id' field.
+    Args:
+        yaml_str_or_dict: YAML as string or dict
+        context: Context string for error messages
+    """
+    if isinstance(yaml_str_or_dict, str):
+        data = yaml.safe_load(yaml_str_or_dict)
+    else:
+        data = yaml_str_or_dict
+
+    # Check jobs
+    jobs = data.get('jobs', {})
+    for job_key, job_data in jobs.items():
+        assert 'id' in job_data, f"{context}: Job '{job_key}' missing 'id' field."
+        assert job_data['id'] not in (None, '', []), f"{context}: Job '{job_key}' has empty 'id' field."
+
+    # Check triggers
+    triggers = data.get('triggers', {})
+    for trig_key, trig_data in triggers.items():
+        assert 'id' in trig_data, f"{context}: Trigger '{trig_key}' missing 'id' field."
+        assert trig_data['id'] not in (None, '', []), f"{context}: Trigger '{trig_key}' has empty 'id' field."
+
+    # Check edges
+    edges = data.get('edges', {})
+    for edge_key, edge_data in edges.items():
+        assert 'id' in edge_data, f"{context}: Edge '{edge_key}' missing 'id' field."
+        assert edge_data['id'] not in (None, '', []), f"{context}: Edge '{edge_key}' has empty 'id' field."
+
+
+def assert_yaml_jobs_have_body(yaml_str_or_dict, context=''):
+    """
+    Assert that every job in the YAML has a non-empty 'body' field.
+    Args:
+        yaml_str_or_dict: YAML as string or dict
+        context: Context string for error messages
+    """
+    if isinstance(yaml_str_or_dict, str):
+        data = yaml.safe_load(yaml_str_or_dict)
+    else:
+        data = yaml_str_or_dict
+
+    jobs = data.get('jobs', {})
+    for job_key, job_data in jobs.items():
+        assert 'body' in job_data, f"{context}: Job '{job_key}' missing 'body' field."
+        assert job_data['body'] not in (None, '', []), f"{context}: Job '{job_key}' has empty 'body' field."

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -86,14 +86,13 @@ class AnthropicClient:
         history = history.copy() if history else []
         
         # Extract and preserve existing components
-        preserved_codes = {}
-        preserved_ids = {}
+        preserved_values = {}
         processed_existing_yaml = existing_yaml
         
         if existing_yaml and existing_yaml.strip():
             try:
                 yaml_data = yaml.safe_load(existing_yaml)
-                preserved_codes, preserved_ids, processed_existing_yaml = self.extract_and_preserve_components(yaml_data)
+                preserved_values, processed_existing_yaml = self.extract_and_preserve_components(yaml_data)
             except Exception as e:
                 logger.warning(f"Could not parse existing YAML for component extraction: {e}")
         
@@ -132,7 +131,8 @@ class AnthropicClient:
                     logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
-            response_text, response_yaml = self.split_format_yaml(response, preserved_codes, preserved_ids)
+            response_text, response_yaml = self.split_format_yaml(response, preserved_values)
+
 
             # If YAML parsing succeeded or we're on the last attempt, return the result
             if response_yaml is not None or attempt == max_retries:
@@ -169,7 +169,7 @@ class AnthropicClient:
                     if original_name != sanitized_name:
                         logger.info(f"Sanitized job name: '{original_name}' -> '{sanitized_name}'")
 
-    def split_format_yaml(self, response, preserved_codes=None, preserved_ids=None):
+    def split_format_yaml(self, response, preserved_values=None):
         """Split text and YAML in response and format the YAML."""
         output_text, output_yaml = "", None
 
@@ -187,7 +187,7 @@ class AnthropicClient:
 
                 self.validate_adaptors(output_yaml)
                 self.sanitize_job_names(output_yaml)
-                self.restore_components(output_yaml, preserved_codes, preserved_ids)
+                self.restore_components(output_yaml, preserved_values)
                 # Convert back to YAML string with preserved order
                 output_yaml = yaml.dump(output_yaml, sort_keys=False)
             else:
@@ -222,89 +222,99 @@ class AnthropicClient:
     def extract_and_preserve_components(self, yaml_data):
         """
         Extract both codes and IDs from all components.
-        Returns: (preserved_codes, preserved_ids, processed_yaml_string)
+        Returns: (preserved_values, processed_yaml_string)
         """
         if not yaml_data:
-            return {}, {}, None
+            return {}, None
         
-        preserved_codes = {}
-        preserved_ids = {}
+        preserved_values = {}
         
         if "jobs" in yaml_data:
             for job_key, job_data in yaml_data["jobs"].items():
+                # Preserve job body code
                 if "body" in job_data:
                     body_content = job_data["body"].strip()
                     if body_content and body_content != "// Add operations here":
-                        preserved_codes[job_key] = {
-                            "code": body_content,
-                            "placeholder": f"__CODE_BLOCK_{job_key}__"
+                        key = f"job_body_{job_key}"
+                        placeholder = f"__CODE_BLOCK_{job_key}__"
+                        preserved_values[key] = {
+                            "value": body_content,
+                            "placeholder": placeholder
                         }
-                        job_data["body"] = preserved_codes[job_key]["placeholder"]
+                        job_data["body"] = placeholder
                 
+                # Preserve job ID
                 if "id" in job_data:
-                    preserved_ids[f"job_{job_key}"] = {
-                        "id": job_data["id"],
-                        "placeholder": f"{{ID_JOB_{job_key}}}"
+                    key = f"job_id_{job_key}"
+                    placeholder = f"{{ID_JOB_{job_key}}}"
+                    preserved_values[key] = {
+                        "value": job_data["id"],
+                        "placeholder": placeholder
                     }
-                    job_data["id"] = preserved_ids[f"job_{job_key}"]["placeholder"]
+                    job_data["id"] = placeholder
         
         if "triggers" in yaml_data:
             for trigger_key, trigger_data in yaml_data["triggers"].items():
                 if "id" in trigger_data:
-                    preserved_ids["trigger"] = trigger_data["id"]
+                    preserved_values["trigger_id"] = trigger_data["id"]
                     # Remove the id key from what we send to the model, as there is only one trigger
                     del trigger_data["id"]
         
         if "edges" in yaml_data:
+            edge_counter = 1
             for edge_key, edge_data in yaml_data["edges"].items():
                 if "id" in edge_data:
-                    preserved_ids[f"edge_{edge_key}"] = {
-                        "id": edge_data["id"],
-                        "placeholder": f"{{ID_EDGE_{edge_key}}}"
+                    key = f"edge_id_{edge_counter}"
+                    placeholder = f"{{ID_EDGE_{edge_counter}}}"
+                    preserved_values[key] = {
+                        "value": edge_data["id"],
+                        "placeholder": placeholder
                     }
-                    edge_data["id"] = preserved_ids[f"edge_{edge_key}"]["placeholder"]
+                    edge_data["id"] = placeholder
+                    edge_counter += 1
         
-        return preserved_codes, preserved_ids, yaml.dump(yaml_data, sort_keys=False)
+        return preserved_values, yaml.dump(yaml_data, sort_keys=False)
 
-    def restore_components(self, yaml_data, preserved_codes=None, preserved_ids=None):
+    def restore_components(self, yaml_data, preserved_values=None):
         """
-        Restore preserved codes and IDs, generate new UUIDs for new components.
+        Restore preserved values, generate new UUIDs for new components.
         """
         if not yaml_data:
             return
         
-        preserved_codes = preserved_codes or {}
-        preserved_ids = preserved_ids or {}
+        preserved_values = preserved_values or {}
         
         if "jobs" in yaml_data:
             for job_key, job_data in yaml_data["jobs"].items():
-                if "body" in job_data:
-                    if job_key in preserved_codes:
-                        job_data["body"] = preserved_codes[job_key]["code"]
-                    else:
-                        job_data["body"] = "// Add operations here"
+                body_key = f"job_body_{job_key}"
+                if body_key in preserved_values:
+                    job_data["body"] = preserved_values[body_key]["value"]
+                elif "body" not in job_data or job_data["body"] == f"__CODE_BLOCK_{job_key}__":
+                    job_data["body"] = "// Add operations here"
                 
-                id_key = f"job_{job_key}"
-                if id_key in preserved_ids:
-                    job_data["id"] = preserved_ids[id_key]["id"]
-                elif "id" not in job_data:
+                id_key = f"job_id_{job_key}"
+                if id_key in preserved_values:
+                    job_data["id"] = preserved_values[id_key]["value"]
+                elif "id" not in job_data or job_data["id"] == f"{{ID_JOB_{job_key}}}":
                     job_data["id"] = str(uuid.uuid4())
         
         if "triggers" in yaml_data:
             for trigger_key, trigger_data in yaml_data["triggers"].items():
-                if "trigger" in preserved_ids:
-                    trigger_data["id"] = preserved_ids["trigger"]
-                else:
+                if "trigger_id" in preserved_values:
+                    trigger_data["id"] = preserved_values["trigger_id"]
+                elif "id" not in trigger_data:
                     trigger_data["id"] = str(uuid.uuid4())
 
         if "edges" in yaml_data:
+            edge_counter = 1
             for edge_key, edge_data in yaml_data["edges"].items():
-                id_key = f"edge_{edge_key}"
-                if id_key in preserved_ids:
-                    edge_data["id"] = preserved_ids[id_key]["id"]
-                elif "id" not in edge_data:
+                id_key = f"edge_id_{edge_counter}"
+                if id_key in preserved_values:
+                    edge_data["id"] = preserved_values[id_key]["value"]
+                elif "id" not in edge_data or edge_data["id"] == f"{{ID_EDGE_{edge_counter}}}":
                     edge_data["id"] = str(uuid.uuid4())
-    
+                edge_counter += 1
+        
 
 
 def main(data_dict: dict) -> dict:

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import uuid
 import unicodedata
 from typing import List, Optional, Dict, Any
 import yaml
@@ -84,18 +85,17 @@ class AnthropicClient:
         """Generate a response using the Claude API. Retry up to 2 times if YAML/JSON parsing fails."""
         history = history.copy() if history else []
         
-        # Extract and preserve existing code if yaml exists
+        # Extract and preserve existing components
         preserved_codes = {}
+        preserved_ids = {}
         processed_existing_yaml = existing_yaml
         
         if existing_yaml and existing_yaml.strip():
             try:
                 yaml_data = yaml.safe_load(existing_yaml)
-                preserved_codes = self.extract_job_codes(yaml_data)
-                if preserved_codes:
-                    processed_existing_yaml = self.replace_codes_with_placeholders(yaml_data, preserved_codes)
+                preserved_codes, preserved_ids, processed_existing_yaml = self.extract_and_preserve_components(yaml_data)
             except Exception as e:
-                logger.warning(f"Could not parse existing YAML for code extraction: {e}")
+                logger.warning(f"Could not parse existing YAML for component extraction: {e}")
         
         system_message, prompt = build_prompt(
             content=content, 
@@ -132,7 +132,7 @@ class AnthropicClient:
                     logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
-            response_text, response_yaml = self.split_format_yaml(response, preserved_codes)
+            response_text, response_yaml = self.split_format_yaml(response, preserved_codes, preserved_ids)
 
             # If YAML parsing succeeded or we're on the last attempt, return the result
             if response_yaml is not None or attempt == max_retries:
@@ -169,7 +169,7 @@ class AnthropicClient:
                     if original_name != sanitized_name:
                         logger.info(f"Sanitized job name: '{original_name}' -> '{sanitized_name}'")
 
-    def split_format_yaml(self, response, preserved_codes=None):
+    def split_format_yaml(self, response, preserved_codes=None, preserved_ids=None):
         """Split text and YAML in response and format the YAML."""
         output_text, output_yaml = "", None
 
@@ -187,7 +187,7 @@ class AnthropicClient:
 
                 self.validate_adaptors(output_yaml)
                 self.sanitize_job_names(output_yaml)
-                self.process_job_bodies(output_yaml, preserved_codes)
+                self.restore_components(output_yaml, preserved_codes, preserved_ids)
                 # Convert back to YAML string with preserved order
                 output_yaml = yaml.dump(output_yaml, sort_keys=False)
             else:
@@ -219,61 +219,93 @@ class AnthropicClient:
         except Exception as e:
             logger.error(f"validate_adaptors encountered an error: {e}")
 
-    def process_job_bodies(self, yaml_data, preserved_codes=None):
+    def extract_and_preserve_components(self, yaml_data):
         """
-        Restore preserved code for existing jobs and set default placeholder for new jobs.
+        Extract both codes and IDs from all components.
+        Returns: (preserved_codes, preserved_ids, processed_yaml_string)
         """
-        if not preserved_codes:
-            preserved_codes = {}
+        if not yaml_data:
+            return {}, {}, None
         
-        expected_default = "// Add operations here"
+        preserved_codes = {}
+        preserved_ids = {}
         
-        if yaml_data and "jobs" in yaml_data:
-            jobs = yaml_data["jobs"]
-            for job_id, job_data in jobs.items():
-                if "body" in job_data:
-                    # If this job exists in preserved codes, restore the original code
-                    if job_id in preserved_codes:
-                        job_data["body"] = preserved_codes[job_id]["code"]
-                    # Handle new jobs created by model - set default placeholder
-                    else:
-                        job_data["body"] = expected_default
-
-    def extract_job_codes(self, yaml_data):
-        """
-        Extract actual code from job bodies and create placeholder mapping.
-        Returns: dict mapping job_id to {code: actual_code, placeholder: unique_id}
-        """
-        code_mapping = {}
-        
-        if yaml_data and "jobs" in yaml_data:
-            jobs = yaml_data["jobs"]
-            for job_id, job_data in jobs.items():
+        if "jobs" in yaml_data:
+            for job_key, job_data in yaml_data["jobs"].items():
                 if "body" in job_data:
                     body_content = job_data["body"].strip()
-                    # Only preserve if it's actual code (not default placeholder)
                     if body_content and body_content != "// Add operations here":
-                        placeholder = self.generate_code_placeholder(job_id)
-                        code_mapping[job_id] = {
+                        preserved_codes[job_key] = {
                             "code": body_content,
-                            "placeholder": placeholder
+                            "placeholder": f"__CODE_BLOCK_{job_key}__"
                         }
+                        job_data["body"] = preserved_codes[job_key]["placeholder"]
+                
+                if "id" in job_data:
+                    preserved_ids[f"job_{job_key}"] = {
+                        "id": job_data["id"],
+                        "placeholder": f"{{ID_JOB_{job_key}}}"
+                    }
+                    job_data["id"] = preserved_ids[f"job_{job_key}"]["placeholder"]
         
-        return code_mapping
-
-    def generate_code_placeholder(self, job_id):
-        """Generate unique, deterministic placeholder for job code."""
-        return f"__CODE_BLOCK_{job_id}__"
-
-    def replace_codes_with_placeholders(self, yaml_data, code_mapping):
-        """Replace actual job bodies with placeholders before sending to model."""
-        if yaml_data and "jobs" in yaml_data:
-            jobs = yaml_data["jobs"]
-            for job_id, job_data in jobs.items():
-                if job_id in code_mapping and "body" in job_data:
-                    job_data["body"] = code_mapping[job_id]["placeholder"]
+        if "triggers" in yaml_data:
+            for trigger_key, trigger_data in yaml_data["triggers"].items():
+                if "id" in trigger_data:
+                    preserved_ids["trigger"] = trigger_data["id"]
+                    # Remove the id key from what we send to the model, as there is only one trigger
+                    del trigger_data["id"]
         
-        return yaml.dump(yaml_data, sort_keys=False)
+        if "edges" in yaml_data:
+            for edge_key, edge_data in yaml_data["edges"].items():
+                if "id" in edge_data:
+                    preserved_ids[f"edge_{edge_key}"] = {
+                        "id": edge_data["id"],
+                        "placeholder": f"{{ID_EDGE_{edge_key}}}"
+                    }
+                    edge_data["id"] = preserved_ids[f"edge_{edge_key}"]["placeholder"]
+        
+        return preserved_codes, preserved_ids, yaml.dump(yaml_data, sort_keys=False)
+
+    def restore_components(self, yaml_data, preserved_codes=None, preserved_ids=None):
+        """
+        Restore preserved codes and IDs, generate new UUIDs for new components.
+        """
+        if not yaml_data:
+            return
+        
+        preserved_codes = preserved_codes or {}
+        preserved_ids = preserved_ids or {}
+        
+        if "jobs" in yaml_data:
+            for job_key, job_data in yaml_data["jobs"].items():
+                if "body" in job_data:
+                    if job_key in preserved_codes:
+                        job_data["body"] = preserved_codes[job_key]["code"]
+                    else:
+                        job_data["body"] = "// Add operations here"
+                
+                id_key = f"job_{job_key}"
+                if id_key in preserved_ids:
+                    job_data["id"] = preserved_ids[id_key]["id"]
+                elif "id" not in job_data:
+                    job_data["id"] = str(uuid.uuid4())
+        
+        if "triggers" in yaml_data:
+            for trigger_key, trigger_data in yaml_data["triggers"].items():
+                if "trigger" in preserved_ids:
+                    trigger_data["id"] = preserved_ids["trigger"]
+                else:
+                    trigger_data["id"] = str(uuid.uuid4())
+
+        if "edges" in yaml_data:
+            for edge_key, edge_data in yaml_data["edges"].items():
+                id_key = f"edge_{edge_key}"
+                if id_key in preserved_ids:
+                    edge_data["id"] = preserved_ids[id_key]["id"]
+                elif "id" not in edge_data:
+                    edge_data["id"] = str(uuid.uuid4())
+    
+
 
 def main(data_dict: dict) -> dict:
     """


### PR DESCRIPTION
## Short Description

This PR helps preserve UUIDs when editing existing workflows with the workflow chat service. It can preserve existing UUIDs and generate new UUIDs for new jobs/edges. 

The service cannot subtly edit existing UUIDs, but it could accidentally re-generate them.

Fixes #257 

See Lightning work: https://github.com/OpenFn/lightning/issues/3247

## Implementation Details
The input JSON format is not changed, but the "existing_yaml" key now includes "id" keys under triggers, jobs and edges.

The UUID preservation follows the existing approach we use for job code preservation: we replace the UUIDs with placeholder strings, that the model is less likely to forget. Then we send the YAML without UUIDs (and without job code) to the LLM. We expect the model to preserve the placeholder strings in the appropriate places (or delete them where necessary) in its output YAML. We then replace these strings with the original UUIDs using the placeholder strings. Where a replacement is not found (if there is a new job/edge, or if the model forgot the correct placeholder string), we generate a new UUID.

We use curly braces and job/edge-name-based placeholder strings to help the LLM remember where UUIDs belong, and to differentiate from code placeholder strings, which use underscores.

Job and edge ID placeholder strings are sent to the model. There can only be one trigger per workflow, so this is not sent to the model, but preserved and added in automatically. Changes to jobs/triggers should not usually lead to a new UUID.

The prompt is adjusted to explain the purpose of the ID placeholders and to ask the model to preserve them where appropriate. The model is instructed to leave ID fields empty for new sections. Whether they are empty or if the model invented a new placeholder string (against instructions), these will be filled in in `workflow_chat.py`

Tests are adjusted for the new YAML format. (TODO)

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
