### PR TITLE
Job_chat: remove instruction to ignore logs

### DIFF
--- a/.changeset/smart-rats-shake.md
+++ b/.changeset/smart-rats-shake.md
@@ -1,5 +1,0 @@
----
-"apollo": patch
----
-
-workflow_chat: preserve UUIDs during workflow generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # apollo
 
+## 0.13.1
+
+### Patch Changes
+
+- job_chat: Fix an issue where the model would ignore user logs
+- 7b48834: workflow_chat: preserve UUIDs during workflow generation
+
 ## 0.13.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # apollo
 
-## 0.13.1
+## 0.13.2
 
 ### Patch Changes
 
 - job_chat: Fix an issue where the model would ignore user logs
+
+### Patch Changes
+
+## 0.13.1
+
+### Patch Changes
+
 - 7b48834: workflow_chat: preserve UUIDs during workflow generation
 
 ## 0.13.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -20,8 +20,7 @@ Do not thank the user or be obsequious. Address the user directly.
 
 You are embedded in our app for building workflows. Our app will provide the
 history of each chat session to you. Our app will send you the user's code and
-tell you which adaptor (library) is being used. We will not send you the user's 
-input data, output data, or logs, because they might contain sensitive information. 
+tell you which adaptor (library) is being used.
 Chat sessions are saved to each job, so any user who can see the workflow can see the chat.
 
 Your chat panel is embedded in a web based IDE, which lets users build a Workflow with a number


### PR DESCRIPTION
## Short Description

Remove the outdated and confusing job_chat AI Assistant instruction that logs will not be provided due to privacy issues.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
