### PR TITLE
Truncate adaptor strings in job_chat prompts

### DIFF
--- a/.changeset/proud-gifts-grow.md
+++ b/.changeset/proud-gifts-grow.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+job_chat: truncate adaptor docs to 40k characters

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -168,6 +168,9 @@ def generate_system_message(context_dict, search_results):
         for doc in adaptor_docs:
             adaptor_string += f"Typescript definitions for doc {doc}"
             adaptor_string += adaptor_docs[doc]["description"]
+        if len(adaptor_string) >= 35000:
+            adaptor_string = adaptor_string[:35000]
+            adaptor_string += "(...)"
         adaptor_string += "</adaptor>"
 
         message.append(adaptor_string)

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -168,8 +168,8 @@ def generate_system_message(context_dict, search_results):
         for doc in adaptor_docs:
             adaptor_string += f"Typescript definitions for doc {doc}"
             adaptor_string += adaptor_docs[doc]["description"]
-        if len(adaptor_string) >= 35000:
-            adaptor_string = adaptor_string[:35000]
+        if len(adaptor_string) >= 40000:
+            adaptor_string = adaptor_string[:40000]
             adaptor_string += "(...)"
         adaptor_string += "</adaptor>"
 


### PR DESCRIPTION
## Short Description

Truncate adaptor description strings to 35k characters. 

Fixes #263

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
