### PR TITLE
job_chat suggest code: make JSON outputs more robust

### DIFF
--- a/.changeset/breezy-pens-cough.md
+++ b/.changeset/breezy-pens-cough.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+Make job_chat json output more robust

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -93,7 +93,7 @@ class AnthropicClient:
                         rag=rag, 
                         api_key=self.api_key
                     )
-                    prompt.append({"role": "assistant", "content": '{\n  "text_answer": "'}) #TODO
+                    prompt.append({"role": "assistant", "content": '{\n  "text_answer": "'})
 
                 else:
                     system_message, prompt, retrieved_knowledge = build_old_prompt(
@@ -123,8 +123,9 @@ class AnthropicClient:
                     logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
-            if suggest_code is True: #TODO
-                response = '{\n  "text_answer": "' + response
+
+            if suggest_code is True:
+                response = '{\n  "text_answer": "' + response # Add back the prefilled opening brace
 
             if suggest_code is True:
                 # Parse JSON response and apply code edits
@@ -279,7 +280,7 @@ class AnthropicClient:
                 full_code=full_code,
                 text_explanation=text_explanation
             )
-            prompt.append({"role": "assistant", "content": '{\n  "explanation": "'}) #TODO
+            prompt.append({"role": "assistant", "content": '{\n  "explanation": "'})
             message = self.client.messages.create(
                 max_tokens=16384,
                 messages=prompt,
@@ -288,7 +289,7 @@ class AnthropicClient:
             )
             
             response = "\n\n".join([block.text for block in message.content if block.type == "text"])
-            response = '{\n  "explanation": "' + response  # Add back the prefilled opening brace #TODO
+            response = '{\n  "explanation": "' + response  # Add back the prefilled opening brace
             correction_data = json.loads(response)
 
             corrected_old = correction_data.get("corrected_old_code")

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -93,6 +93,8 @@ class AnthropicClient:
                         rag=rag, 
                         api_key=self.api_key
                     )
+                    prompt.append({"role": "assistant", "content": '{\n  "text_answer": "'}) #TODO
+
                 else:
                     system_message, prompt, retrieved_knowledge = build_old_prompt(
                         content=content, 
@@ -121,6 +123,8 @@ class AnthropicClient:
                     logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
+            if suggest_code is True: #TODO
+                response = '{\n  "text_answer": "' + response
 
             if suggest_code is True:
                 # Parse JSON response and apply code edits
@@ -275,7 +279,7 @@ class AnthropicClient:
                 full_code=full_code,
                 text_explanation=text_explanation
             )
-            
+            prompt.append({"role": "assistant", "content": '{\n  "explanation": "'}) #TODO
             message = self.client.messages.create(
                 max_tokens=16384,
                 messages=prompt,
@@ -284,8 +288,9 @@ class AnthropicClient:
             )
             
             response = "\n\n".join([block.text for block in message.content if block.type == "text"])
+            response = '{\n  "explanation": "' + response  # Add back the prefilled opening brace #TODO
             correction_data = json.loads(response)
-            
+
             corrected_old = correction_data.get("corrected_old_code")
             corrected_new = correction_data.get("corrected_new_code")
             logger.info(f"Corrector response: {response}")

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -334,7 +334,9 @@ def build_prompt(content, history, context, rag=None, api_key=None):
             "generate_queries": {}
         }
     }
-    
+    # Remove escaped newlines which confuse the model
+    # context["expression"] = context["expression"].encode().decode('unicode_escape')
+
     if rag:
         retrieved_knowledge = rag
     else:
@@ -348,7 +350,7 @@ def build_prompt(content, history, context, rag=None, api_key=None):
           )
       except Exception as e:
           logger.error(f"Error retrieving knowledge: {str(e)}")
-
+    
     system_message = generate_system_message(
         context_dict=context, 
         search_results=retrieved_knowledge.get("search_results") if retrieved_knowledge is not None else None)

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -173,12 +173,13 @@ We will use literal string replacement to apply your changes. To avoid duplicate
 1. Include ample surrounding context in the old_code to replace (comments, variable declarations, both similar pasages etc.)
 2. If in doubt, use "rewrite" action instead to rewrite the whole code
 
-**Output valid JSON strings**  
-All string values in your JSON (including "old_code", "new_code", and "text_answer") must be valid JSON strings.  
-- Escape all newlines as \\n  
-- Escape all double quotes as \\"  
+**Output valid JSON strings**
+Your answer MUST be parseable with json.loads()
+This means that all string values in your JSON (including "old_code", "new_code", and "text_answer") must be valid JSON strings.  
+- Escape all newlines as \\n (one backslash followed by n)  
+- Escape all double quotes as \\"  (one backslash followed by double quotation mark)  
 - Do not include unescaped control characters in any string value.  
-- If you include code in a string, ensure it is a single line with \\n for line breaks.
+- When you include code in a string, ensure it is a single line with \\n for line breaks.
 
 Example:
 {
@@ -189,6 +190,15 @@ Example:
     "new_code": "get('/patients');\\nfn(state => {\\n  if (!state.data) {\\n    throw new Error(\\\"No data received\\\");\\n  }\\n  return state;\\n});"
   }]
 }
+
+ALWAYS use \\n instead of actual newlines:
+THIS IS WRONG:
+"new_code": "function() {
+  return true;
+}"
+
+THIS IS CORRECT:
+"new_code": "function() {\\n  return true;\\n}"
 </code editing rules>
 </output format>
 """
@@ -226,6 +236,22 @@ Output JSON format:
   "corrected_old_code": "corrected old code with proper context",
   "corrected_new_code": "corrected new code"
 }
+
+**Output valid JSON strings**
+Your answer MUST be parseable with json.loads()
+- Escape all newlines as \\n (one backslash followed by n)  
+- Escape all double quotes as \\"  (one backslash followed by double quotation mark)  
+- Do not include unescaped control characters in any string value.  
+- When you include code in a string, ensure it is a single line with \\n for line breaks.
+
+ALWAYS use \\n instead of actual newlines:
+THIS IS WRONG:
+"corrected_new_code": "function() {
+  return true;
+}"
+
+THIS IS CORRECT:
+"corrected_new_code": "function() {\\n  return true;\\n}"
 """
 
 

--- a/services/job_chat/tests/test_pass_fail.py
+++ b/services/job_chat/tests/test_pass_fail.py
@@ -52,7 +52,8 @@ fn(state => {
   return { ...state, transformed };
 });
 
-post('https://destination.org/upload', state => state.transformed);'''
+post('https://destination.org/upload', state => state.transformed);''',
+        "adaptor": "@openfn/language-salesforce@8.0.0"
     }
     
     expected_code = '''// Get data from external API
@@ -105,7 +106,8 @@ post('https://api.example.com/save', state => ({
 }));'''
     
     context = {
-        "expression": original_code
+        "expression": original_code,
+        "adaptor": "@openfn/language-salesforce@8.0.0"
     }
     
     # Service correctly uses 'del()' instead of 'delete()' (delete is reserved word in JS)
@@ -207,7 +209,8 @@ post(
     summary: state.summary,
     endpoint: getPatientData('summary')
   })
-);'''
+);''',
+        "adaptor": "@openfn/language-whatsapp@1.0.4"
     }
     
     expected_code = context["expression"].replace("getPatientData", "fetchPatientRecords")
@@ -328,7 +331,8 @@ post('https://notifications.example.com/endpooint/status', state => ({
 }));'''
     
     context = {
-        "expression": original_code
+        "expression": original_code,
+        "adaptor": "@openfn/language-googlesheets@4.0.1"
     }
     
     expected_code = original_code.replace("endpooint", "endpoint").replace("endpoooint", "endpoint")
@@ -376,7 +380,8 @@ fn(state => {
 post('/webhook', state => state.data);'''
     
     context = {
-        "expression": original_code
+        "expression": original_code,
+        "adaptor": "@openfn/language-kobotoolbox@4.2.3"
     }
     
     expected_code = original_code.replace('const data', 'const patients') \

--- a/services/job_chat/tests/test_qualitative.py
+++ b/services/job_chat/tests/test_qualitative.py
@@ -24,7 +24,8 @@ fn(state => {
 });
 
 // Send transformed data to destination
-post('https://destination.org/upload', state => state.transformed);'''
+post('https://destination.org/upload', state => state.transformed);''',
+        "adaptor": "@openfn/language-gmail@2.0.2"
     }
     meta = {}
     service_input = make_service_input(history=history, content=content, context=context, meta=meta, suggest_code=True)
@@ -64,7 +65,8 @@ fn(state => {
 post('https://destination.org/upload', state => state.transformed);''',
         "adaptors": ["@openfn/language-http", "@openfn/language-common"],
         "jobId": "job-abc123",
-        "projectId": "project-xyz789"
+        "projectId": "project-xyz789",
+        "adaptor": "@openfn/language-fhir-4@0.1.10"
     }
     
     meta = {
@@ -93,6 +95,7 @@ post('https://destination.org/upload', state => state.transformed);''',
     assert "suggested_code" in response
     assert "meta" in response
     assert "usage" in response
+    assert response["suggested_code"] is not None, "JSON parsing failed - suggested_code is None"
     assert response["suggested_code"] != context["expression"], "Suggested code should be different from the original code"
 
 def test_duplicate_sections():
@@ -150,7 +153,8 @@ def test_duplicate_sections():
       )
     )
   )
-);'''
+);''',
+        "adaptor": "@openfn/language-dhis2@8.0.1"
     }
     meta = {}
     service_input = make_service_input(history=history, content=content, context=context, meta=meta, suggest_code=True)
@@ -159,6 +163,7 @@ def test_duplicate_sections():
     assert response is not None
     assert "response" in response
     assert "suggested_code" in response
+    assert response["suggested_code"] is not None, "JSON parsing failed - suggested_code is None"
     assert response["suggested_code"] != context["expression"], "Suggested code should be different from the original code"
 
 def test_duplicate_sections_additional():
@@ -189,7 +194,8 @@ post('https://api.example.com/endpoint', state => state.items);
 
 post('https://api.example.com/endpoint', state => state.items);
 
-post('https://api.example.com/endpoint', state => state.items);'''
+post('https://api.example.com/endpoint', state => state.items);''',
+        "adaptor": "@openfn/language-mailchimp@1.0.19"
     }
     meta = {}
     service_input = make_service_input(history=history, content=content, context=context, meta=meta, suggest_code=True)
@@ -198,4 +204,5 @@ post('https://api.example.com/endpoint', state => state.items);'''
     assert response is not None
     assert "response" in response
     assert "suggested_code" in response
+    assert response["suggested_code"] is not None, "JSON parsing failed - suggested_code is None"
     assert response["suggested_code"] != context["expression"], "Suggested code should be different from the original code"


### PR DESCRIPTION
## Short Description

This fix makes `job_chat` responses that are in the new `suggest_code` JSON format more robust and less likely to have JSON control character errors. 

## Implementation Details

### 1) Prompt changes
- Both the main prompt and the correction prompt specify we are using json.loads() and further instructions about escaping newlines.

### 2) Use answer prefilling
- Anthropic doesn't have JSON mode but recommends prefilling the assistant's answers with an opening bracket. This is added in now in the the main LLM call and the correction call.

### 3) Improve tests
- Tests now specifically check for a `None` value in `suggested_code`, instead of just the presence of the `suggested_code` field in the service output
-  Tests now specify adaptors where relevant. The previous tests were too targeted at basic functionality. When adding long adaptor documentation, as we would in production, the model's ability to follow critical instructions e.g. about valid output format is weakened. 

These fixes may not be sufficient. I couldn't find a simple way to correct malformed JSON from the model. Further fixes could include e.g. external libraries like `json_repair`, or switching from JSON to markdown.

If the tests accurately reflect the inputs from Lightning, then the JSON parsing error is rare. However, we need to check with real inputs from Lightning to make sure.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
