### PR TITLE
workflow_chat: add job name sanitisation for edges

### DIFF
--- a/.changeset/clean-fishes-guess.md
+++ b/.changeset/clean-fishes-guess.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+add sanitisation to edges in yaml

--- a/services/workflow_chat/tests/test_pass_fail.py
+++ b/services/workflow_chat/tests/test_pass_fail.py
@@ -51,7 +51,7 @@ edges:
     content = "Actually I want to schedule it for midnight every day."
     service_input = make_service_input(existing_yaml, history, content=content)
     response = call_workflow_chat_service(service_input)
-    print_response_details(response, "change_trigger", content=content)
+    print_response_details(response, content=content)
     assert response is not None
     assert isinstance(response, dict)
     
@@ -65,13 +65,13 @@ edges:
     assert triggers["cron"].get("cron_expression") == "0 0 * * *", f"Expected cron_expression '0 0 * * *', got: {triggers['cron'].get('cron_expression')}"
     assert "webhook" not in triggers, "webhook trigger should have been replaced by cron"
 
-    # Use the reusable function to assert only triggers changed
     orig_yaml = yaml.safe_load(existing_yaml)
     assert_yaml_equal_except(
         orig_yaml, parsed,
         allowed_paths=["triggers", "edges"],
         context="YAML changed outside triggers or edges section."
     )
+    assert_no_special_chars(response["response_yaml"], context="test_change_trigger")
 
 
 def test_rename_two_jobs_commcare():
@@ -195,7 +195,7 @@ edges:
 """
     service_input = make_service_input(existing_yaml, history, content=content)
     response = call_workflow_chat_service(service_input)
-    print_response_details(response, "rename_two_jobs_commcare", content=content)
+    print_response_details(response, content=content)
     assert response is not None
     assert isinstance(response, dict)
 
@@ -204,6 +204,7 @@ edges:
     parsed = yaml.safe_load(yaml_str)
     expected = yaml.safe_load(target_yaml)
     assert parsed == expected
+    assert_no_special_chars(response["response_yaml"], context="test_rename_two_jobs_commcare")
 
 def test_special_characters():
     print("==================TEST==================")
@@ -218,7 +219,7 @@ def test_special_characters():
     content = "data about water systems and water sales"
     service_input = make_service_input(existing_yaml, history, content=content)
     response = call_workflow_chat_service(service_input)
-    print_response_details(response, "empty_water_bug", content=content)
+    print_response_details(response, content=content)
     assert response is not None
     assert isinstance(response, dict)
 

--- a/services/workflow_chat/tests/test_qualitative.py
+++ b/services/workflow_chat/tests/test_qualitative.py
@@ -5,9 +5,9 @@ import json
 import sys
 import tempfile
 import subprocess
-from pathlib import Path
-from .test_utils import call_workflow_chat_service, make_service_input, print_response_details, assert_yaml_section_contains_all, assert_yaml_has_ids, assert_yaml_jobs_have_body
 import yaml
+from pathlib import Path
+from .test_utils import call_workflow_chat_service, make_service_input, print_response_details, assert_yaml_section_contains_all, assert_yaml_has_ids, assert_yaml_jobs_have_body, assert_no_special_chars
 
 # ---- TESTS ----
 def test_basic_input():
@@ -162,27 +162,6 @@ edges:
         response_yaml = yaml.safe_load(response_yaml_str)
         # Check that the entire YAML is unchanged
         assert orig_yaml == response_yaml, "If YAML is present in response, it must be unchanged."
-
-def test_special_characters():
-    print("==================TEST==================")
-    print("Description: Ask for a workflow that uses platforms with special characters in their names. "
-          "Verify that diacritics and punctuation removed/normalised correctly (e.g. é->e) in job names "
-          "in the generated YAML.")
-    existing_yaml = """"""
-    history = [
-        {"role": "user", "content": "Create a workflow that retrieves data from mwater, google sheets, netsuite, ferntech.io and processed it and sends it to frappé"},
-        {"role": "assistant", "content": "I'll need more information about your workflow to create an accurate YAML. Specifically: What kind of data are you retrieving from each source (mWater, Google Sheets, NetSuite, ferntech.io)? What processing needs to be done on this data? What type of data needs to be sent to Frappé? Should this workflow run on a schedule or be triggered by an event? With these details, I can create a proper workflow structure for you."}
-    ]
-    content = "data about water systems and water sales"
-    service_input = make_service_input(existing_yaml, history, content=content)
-    response = call_workflow_chat_service(service_input)
-    print_response_details(response, "empty_water_bug", content=content)
-    assert response is not None
-    assert isinstance(response, dict)
-    # Check for id fields in generated YAML
-    if response.get("response_yaml"):
-        assert_yaml_has_ids(response["response_yaml"], context="test_special_characters")
-        assert_yaml_jobs_have_body(response["response_yaml"], context="test_special_characters")
 
 def test_simple_lang_bug():
     print("==================TEST==================")
@@ -485,6 +464,28 @@ edges:
 
     assert_yaml_section_contains_all(existing_yaml, response.get("response_yaml", ""), "jobs", context="Jobs section")
     assert_yaml_section_contains_all(existing_yaml, response.get("response_yaml", ""), "edges", context="Edges section")
+
+def test_special_characters():
+    print("==================TEST==================")
+    print("Description: Ask for a workflow that uses platforms with special characters in their names. "
+          "Verify that diacritics and punctuation removed/normalised correctly (e.g. é->e) in job names "
+          "in the generated YAML.")
+    existing_yaml = """"""
+    history = [
+        {"role": "user", "content": "Create a workflow that retrieves data from mwater, google sheets, netsuite, ferntech.io and processed it and sends it to frappé"},
+        {"role": "assistant", "content": "I'll need more information about your workflow to create an accurate YAML. Specifically: What kind of data are you retrieving from each source (mWater, Google Sheets, NetSuite, ferntech.io)? What processing needs to be done on this data? What type of data needs to be sent to Frappé? Should this workflow run on a schedule or be triggered by an event? With these details, I can create a proper workflow structure for you."}
+    ]
+    content = "data about water systems and water sales"
+    service_input = make_service_input(existing_yaml, history, content=content)
+    response = call_workflow_chat_service(service_input)
+    print_response_details(response, "empty_water_bug", content=content)
+    assert response is not None
+    assert isinstance(response, dict)
+    # Check for id fields in generated YAML
+    if response.get("response_yaml"):
+        assert_yaml_has_ids(response["response_yaml"], context="test_special_characters")
+        assert_yaml_jobs_have_body(response["response_yaml"], context="test_special_characters")
+        assert_no_special_chars(response["response_yaml"], context="test_special_characters")
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/services/workflow_chat/tests/test_utils.py
+++ b/services/workflow_chat/tests/test_utils.py
@@ -108,7 +108,7 @@ def make_service_input(existing_yaml, history, content=None, errors=None):
     return service_input
 
 
-def print_response_details(response, test_name, content=None, errors=None):
+def print_response_details(response, content=None, errors=None):
     """Print detailed response information like the original script, including content or errors if provided."""
     if content is not None:
         print("\nUSER CONTENT:")

--- a/services/workflow_chat/tests/test_utils.py
+++ b/services/workflow_chat/tests/test_utils.py
@@ -215,3 +215,42 @@ def assert_yaml_jobs_have_body(yaml_str_or_dict, context=''):
     for job_key, job_data in jobs.items():
         assert 'body' in job_data, f"{context}: Job '{job_key}' missing 'body' field."
         assert job_data['body'] not in (None, '', []), f"{context}: Job '{job_key}' has empty 'body' field."
+
+def assert_no_special_chars(yaml_str_or_dict, context=''):
+    """
+    Assert that there are no special characters in job names, source_job and target_job fields.
+    Special characters are anything that's not alphanumeric, space, hyphen, or underscore.
+    
+    Args:
+        yaml_str_or_dict: YAML as string or dict
+        context: Context string for error messages
+    """
+    import re
+    if isinstance(yaml_str_or_dict, str):
+        data = yaml.safe_load(yaml_str_or_dict)
+    else:
+        data = yaml_str_or_dict
+    
+    # Pattern matches any character that is NOT alphanumeric, space, hyphen, or underscore
+    special_char_pattern = re.compile(r'[^a-zA-Z0-9\s\-_]')
+    
+    # Check job names
+    jobs = data.get('jobs', {})
+    for job_key, job_data in jobs.items():
+        if 'name' in job_data and job_data['name']:
+            name = str(job_data['name'])
+            match = special_char_pattern.search(name)
+            assert not match, f"{context}: Job '{job_key}' name '{name}' contains special character '{match.group(0)}'"
+    
+    # Check edge: source_job and target_job
+    edges = data.get('edges', {})
+    for edge_key, edge_data in edges.items():
+        if 'source_job' in edge_data and edge_data['source_job']:
+            source = str(edge_data['source_job'])
+            match = special_char_pattern.search(source)
+            assert not match, f"{context}: Edge '{edge_key}' source_job '{source}' contains special character '{match.group(0)}'"
+        
+        if 'target_job' in edge_data and edge_data['target_job']:
+            target = str(edge_data['target_job'])
+            match = special_char_pattern.search(target)
+            assert not match, f"{context}: Edge '{edge_key}' target_job '{target}' contains special character '{match.group(0)}'"

--- a/services/workflow_chat/tests/test_utils.py
+++ b/services/workflow_chat/tests/test_utils.py
@@ -242,7 +242,7 @@ def assert_no_special_chars(yaml_str_or_dict, context=''):
             match = special_char_pattern.search(name)
             assert not match, f"{context}: Job '{job_key}' name '{name}' contains special character '{match.group(0)}'"
     
-    # Check edge: source_job and target_job
+    # Check edge: source_job, target_job and edge key
     edges = data.get('edges', {})
     for edge_key, edge_data in edges.items():
         if 'source_job' in edge_data and edge_data['source_job']:
@@ -254,3 +254,12 @@ def assert_no_special_chars(yaml_str_or_dict, context=''):
             target = str(edge_data['target_job'])
             match = special_char_pattern.search(target)
             assert not match, f"{context}: Edge '{edge_key}' target_job '{target}' contains special character '{match.group(0)}'"
+
+        if "->" in edge_key:
+            source_part, target_part = edge_key.split("->", 1)
+            
+            match = special_char_pattern.search(source_part)
+            assert not match, f"{context}: Edge key '{edge_key}' source part '{source_part}' contains special character '{match.group(0)}'"
+            
+            match = special_char_pattern.search(target_part)
+            assert not match, f"{context}: Edge key '{edge_key}' target part '{target_part}' contains special character '{match.group(0)}'"

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -158,22 +158,56 @@ class AnthropicClient:
                 logger.warning(f"YAML parsing failed, retrying generation (attempt {attempt+1}/{max_retries})")
 
     def sanitize_job_names(self, yaml_data):
-        """Sanitize job names by removing special characters and normalizing diacritics."""
-        if yaml_data and "jobs" in yaml_data:
+        """
+        Sanitize job names by removing special characters and normalizing diacritics.
+        Also sanitizes job references in edges (source and target fields).
+        """
+        if not yaml_data:
+            return
+            
+        # Helper function to sanitize a single name
+        def sanitize_single_name(name):
+            if not name or not isinstance(name, str):
+                return name
+            # Normalize unicode characters (removes diacritics)
+            normalized = unicodedata.normalize('NFKD', name)
+            ascii_name = normalized.encode('ascii', 'ignore').decode('ascii')
+            # Keep only alphanumeric, spaces, hyphens, and underscores
+            return re.sub(r'[^a-zA-Z0-9\s\-_]', '', ascii_name)
+        
+        # First sanitize job names in the jobs section
+        if "jobs" in yaml_data:
             jobs = yaml_data["jobs"]
+            # Create a mapping of original to sanitized names
+            name_mapping = {}
+            
             for job_key, job_data in jobs.items():
                 if "name" in job_data:
                     original_name = str(job_data["name"])
-                    # Normalize unicode characters (removes diacritics)
-                    normalized = unicodedata.normalize('NFKD', original_name)
-                    ascii_name = normalized.encode('ascii', 'ignore').decode('ascii')
-                    # Keep only alphanumeric, spaces, hyphens, and underscores
-                    sanitized_name = re.sub(r'[^a-zA-Z0-9\s\-_]', '', ascii_name)
+                    sanitized_name = sanitize_single_name(original_name)
                     
                     job_data["name"] = sanitized_name
+                    name_mapping[original_name] = sanitized_name
                     
                     if original_name != sanitized_name:
                         logger.info(f"Sanitized job name: '{original_name}' -> '{sanitized_name}'")
+        
+        # Now sanitize job references in the edges section
+        if "edges" in yaml_data:
+            for edge_key, edge_data in yaml_data["edges"].items():
+                # Sanitize source field
+                if "source_job" in edge_data:
+                    original_source = str(edge_data["source_job"])
+                    edge_data["source_job"] = sanitize_single_name(original_source)
+                    if original_source != edge_data["source_job"]:
+                        logger.info(f"Sanitized edge source_job: '{original_source}' -> '{edge_data['source_job']}'")
+                
+                # Sanitize target field
+                if "target_job" in edge_data:
+                    original_target = str(edge_data["target_job"])
+                    edge_data["target_job"] = sanitize_single_name(original_target)
+                    if original_target != edge_data["target_job"]:
+                        logger.info(f"Sanitized edge target_job: '{original_target}' -> '{edge_data['target_job']}'")
 
     def split_format_yaml(self, response, preserved_values=None):
         """Split text and YAML in response and format the YAML."""


### PR DESCRIPTION
## Short Description

Expands YAML sanitisation from job names to edges (edge key, source job, target job)

Expands testing to check this sanitisation is done for all outputs, including edges.

Fixes #277

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
