### PR TITLE
roughly hook up a generic event processor to the websocket

### DIFF
--- a/platform/src/bridge.ts
+++ b/platform/src/bridge.ts
@@ -14,7 +14,8 @@ export const run = async (
   scriptName: string,
   port: number, // needed for self-calling services in pythonland
   args: JSON,
-  onLog?: (str: string) => void
+  onLog?: (str: string) => void,
+  onEvent?: (type: string, payload: any /* string or json tbh */) => void
 ) => {
   return new Promise<JSON | null>(async (resolve, reject) => {
     const id = crypto.randomUUID();
@@ -85,6 +86,17 @@ export const run = async (
         // TODO I'd love to break the log line up in to JSON actually
         // { source, level, message }
         onLog?.(line);
+      } else if (/^(EVENT)\:/.test(line)) {
+        // TODO does the event encoding need to be any more complex than this?
+        // Nice that it stays human readable
+        const [_prefix, type, ...payload] = line.split(":");
+        let processedPayload = payload.join(":");
+        try {
+          processedPayload = JSON.parse(processedPayload);
+        } catch (e) {
+          // No json, no problem
+        }
+        onEvent?.(type, processedPayload);
       }
     });
 

--- a/platform/src/middleware/services.ts
+++ b/platform/src/middleware/services.ts
@@ -63,8 +63,15 @@ export default async (app: Elysia, port: number) => {
                   data: log,
                 });
               };
+              const onEvent = (type: string, payload: any) => {
+                ws.send({
+                  event: "event",
+                  type,
+                  data: payload,
+                });
+              };
 
-              callService(m, port, message.data as any, onLog).then(
+              callService(m, port, message.data as any, onLog, onEvent).then(
                 (result) => {
                   ws.send({
                     event: "complete",


### PR DESCRIPTION
Quickly plugged in a little processor to emit events through the websocket (not just logs)

Events have a type (like "status" or "token") and a payload. The payload can be stringified json

This won't be compatible with CLI out of the box, because CLI looks for log events, not event events, from the streaming API. I might quickly hook something up later today.