### PR TITLE
Auto-tag on merge to main

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - main
-      - auto-tag-gh-action
 
 env:
-  TAG_PREFIX: "TEST@"
+  TAG_PREFIX: "@openfn/apollo@"
 
 jobs:
   tag-release:


### PR DESCRIPTION
New github action which, on merge to main, generates and pushes a tag, which in turn triggers a build

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
