### PR TITLE
add branching explanation to prompt

### DIFF
--- a/.changeset/yummy-ties-tap.md
+++ b/.changeset/yummy-ties-tap.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+workflow_chat: improve the model's understanding of edge branching behaviour

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -14,7 +14,7 @@ from anthropic import (
     InternalServerError,
 )
 import sentry_sdk
-from util import ApolloError, create_logger, AdaptorSpecifier
+from util import ApolloError, create_logger, AdaptorSpecifier, add_page_prefix
 from .prompt import build_prompt, build_error_correction_prompt
 from .old_prompt import build_old_prompt
 from streaming_util import StreamManager
@@ -22,26 +22,7 @@ from streaming_util import StreamManager
 logger = create_logger("job_chat")
 
 
-# Helper functions for page navigation
-def add_page_prefix(content: str, page: Optional[dict]) -> str:
-    """Add [pg:...] prefix to message."""
-    if not page:
-        return content
-
-    prefix_parts = []
-    if page.get('type'):
-        prefix_parts.append(str(page['type']))
-    if page.get('name'):
-        prefix_parts.append(str(page['name']))
-    if page.get('adaptor'):
-        prefix_parts.append(str(page['adaptor']))
-
-    if not prefix_parts:
-        return content
-
-    prefix = f"[pg:{'/'.join(prefix_parts)}]"
-    return f"{prefix} {content}"
-
+# Helper function for page navigation
 def has_navigated(current_page: Optional[dict], last_page: Optional[dict]) -> bool:
     """Check if user navigated to a different page."""
     if not current_page or not last_page:

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -21,6 +21,73 @@ from streaming_util import StreamManager
 
 logger = create_logger("job_chat")
 
+
+# Schema for code suggestions mode
+CODE_SUGGESTIONS_OUTPUT_SCHEMA = {
+    "type": "json_schema",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "text_answer": {
+                "type": "string",
+                "description": "Conversational explanation or response to user"
+            },
+            "code_edits": {
+                "type": "array",
+                "description": "List of code edit operations to apply",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["replace", "rewrite"],
+                            "description": "Type of edit: 'replace' for exact match, 'rewrite' for full replacement"
+                        },
+                        "old_code": {
+                            "type": "string",
+                            "description": "Exact code string to find (for replace action)"
+                        },
+                        "new_code": {
+                            "type": "string",
+                            "description": "New code to insert"
+                        }
+                    },
+                    "required": ["action", "old_code", "new_code"],
+                    "additionalProperties": False
+                }
+            }
+        },
+        "required": ["text_answer", "code_edits"],
+        "additionalProperties": False
+    }
+}
+
+
+# Schema for error correction mode
+ERROR_CORRECTION_OUTPUT_SCHEMA = {
+    "type": "json_schema",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "explanation": {
+                "type": "string",
+                "description": "1-sentence explanation of the correction"
+            },
+            "corrected_old_code": {
+                "type": "string",
+                "description": "Corrected old code with proper context"
+            },
+            "corrected_new_code": {
+                "type": "string",
+                "description": "Corrected new code"
+            }
+        },
+        "required": ["explanation", "corrected_old_code", "corrected_new_code"],
+        "additionalProperties": False
+    }
+}
+
+
 # Helper functions for page navigation
 def add_page_prefix(content: str, page: Optional[dict]) -> str:
     """Add [pg:...] prefix to message."""
@@ -140,8 +207,6 @@ class AnthropicClient:
                         download_adaptor_docs=download_adaptor_docs,
                         refresh_rag=refresh_rag
                     )
-                    prompt.append({"role": "assistant", "content": '{\n  "text_answer": "'})
-
                 else:
                     system_message, prompt, retrieved_knowledge = build_old_prompt(
                         content=content,
@@ -160,12 +225,19 @@ class AnthropicClient:
                     sent_length = 0
                     accumulated_response = ""
 
-                    with self.client.messages.stream(
-                        max_tokens=self.config.max_tokens,
-                        messages=prompt,
-                        model=self.config.model,
-                        system=system_message
-                    ) as stream_obj:
+                    stream_params = {
+                        "max_tokens": self.config.max_tokens,
+                        "messages": prompt,
+                        "model": self.config.model,
+                        "system": system_message
+                    }
+
+                    # Add structured outputs for code suggestions mode
+                    if suggest_code:
+                        stream_params["betas"] = ["structured-outputs-2025-11-13"]
+                        stream_params["output_format"] = CODE_SUGGESTIONS_OUTPUT_SCHEMA
+
+                    with self.client.messages.stream(**stream_params) as stream_obj:
                         for event in stream_obj:
                             accumulated_response, text_complete, sent_length = self.process_stream_event(
                                 event,
@@ -187,9 +259,19 @@ class AnthropicClient:
 
                 else:
                     logger.info("Making non-streaming API call")
-                    message = self.client.messages.create(
-                        max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message
-                    )
+                    create_params = {
+                        "max_tokens": self.config.max_tokens,
+                        "messages": prompt,
+                        "model": self.config.model,
+                        "system": system_message
+                    }
+
+                    # Add structured outputs for code suggestions mode
+                    if suggest_code:
+                        create_params["betas"] = ["structured-outputs-2025-11-13"]
+                        create_params["output_format"] = CODE_SUGGESTIONS_OUTPUT_SCHEMA
+
+                    message = self.client.messages.create(**create_params)
 
             if hasattr(message, "usage"):
                 if message.usage.cache_creation_input_tokens:
@@ -205,9 +287,6 @@ class AnthropicClient:
                     logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
-
-            if suggest_code is True:
-                response = '{\n  "text_answer": "' + response # Add back the prefilled opening brace
 
             if suggest_code is True:
                 # Parse JSON response and apply code edits
@@ -415,16 +494,16 @@ class AnthropicClient:
                 full_code=full_code,
                 text_explanation=text_explanation
             )
-            prompt.append({"role": "assistant", "content": '{\n  "explanation": "'})
             message = self.client.messages.create(
                 max_tokens=16384,
                 messages=prompt,
                 model=self.config.model,
-                system=system_message
+                system=system_message,
+                betas=["structured-outputs-2025-11-13"],
+                output_format=ERROR_CORRECTION_OUTPUT_SCHEMA
             )
-            
+
             response = "\n\n".join([block.text for block in message.content if block.type == "text"])
-            response = '{\n  "explanation": "' + response  # Add back the prefilled opening brace
             correction_data = json.loads(response)
 
             corrected_old = correction_data.get("corrected_old_code")

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -11,8 +11,8 @@ system_role = """
 You are a software engineer helping a non-expert user write a job for our platform.
 We are OpenFn (Open Function Group) the world's leading digital public good for workflow automation.
 
-Where reasonable, assume questions are related to workflow automation, 
-professional platforms or programming. You may provide general information around these topics, 
+Where reasonable, assume questions are related to workflow automation,
+professional platforms or programming. You may provide general information around these topics,
 e.g. general programming assistance unrelated to job writing.
 If a question is entirely irrelevant, do not answer it.
 
@@ -24,12 +24,15 @@ Do not thank the user or be obsequious. Address the user directly.
 
 You are embedded in our app for building workflows. Our app will provide the
 history of each chat session to you. Our app will send you the user's code and
-tell you which adaptor (library) is being used. 
+tell you which adaptor (library) is being used.
 Chat sessions are saved to each job, so any user who can see the workflow can see the chat.
 
 Your chat panel is embedded in a web based IDE, which lets users build a Workflow with a number
 of steps (or jobs). There is a code editor next to you, which users can copy and paste code into.
 Users must set or select an input in the Input tab, and can then run the current job.
+
+You ONLY help with job code. Do NOT help with overall workflow structure.
+If the user wants to add/remove/edit workflow steps, tell them to navigate to the workflow overview.
 
 Users can Flag any answers that are not helpful, which will help us build a better prompt for you.
 
@@ -48,6 +51,10 @@ The system will provide you with various pieces of context about the user's job 
 When the user asks you to check logs or debug an error, the <run_logs> tag will contain the
 relevant execution information. Pay close attention to error messages, stack traces, and the
 sequence of log statements to understand what went wrong.
+
+Earlier turns may have pertained to different context (workflow structure or other job steps) that is no longer
+attached. Any previously generated code has been redacted from history. Some turns may have a [pg:...]
+prefix showing the user's page context at that time.
 </context tags>
 """
 

--- a/services/job_chat/tests/test_pass_fail.py
+++ b/services/job_chat/tests/test_pass_fail.py
@@ -372,7 +372,7 @@ fn(state => {
     }
   });
   
-  console.log(`Processed ${processedData.length} records from data`);
+  console.log(`Processed ${processedData.length} records`);
   
   return { ...state, data: processedData };
 });

--- a/services/job_chat/tests/test_pass_fail.py
+++ b/services/job_chat/tests/test_pass_fail.py
@@ -421,7 +421,7 @@ fn(state => {
     }
   });
 
-  console.log(`Processed ${processedData.length} records from data`);
+  console.log(`Processed ${processedData.length} records`);
 
   return { ...state, data: processedData };
 });

--- a/services/util.py
+++ b/services/util.py
@@ -167,3 +167,37 @@ class AdaptorSpecifier:
     def short_name(self) -> str:
         """Short name without @openfn/language- prefix: 'http'"""
         return self.name.split("/")[-1].replace("language-", "")
+
+
+def add_page_prefix(content: str, page: Optional[dict]) -> str:
+    """
+    Add [pg:...] prefix to message for page navigation tracking.
+
+    Args:
+        content: The message content to prefix
+        page: Dictionary containing page metadata with optional 'type', 'name', and 'adaptor' keys
+
+    Returns:
+        The content with a [pg:type/name/adaptor] prefix if page data is present,
+        otherwise returns the original content unchanged.
+
+    Example:
+        >>> add_page_prefix("Hello", {"type": "job_code", "name": "Transform", "adaptor": "http"})
+        "[pg:job_code/Transform/http] Hello"
+    """
+    if not page:
+        return content
+
+    prefix_parts = []
+    if page.get('type'):
+        prefix_parts.append(str(page['type']))
+    if page.get('name'):
+        prefix_parts.append(str(page['name']))
+    if page.get('adaptor'):
+        prefix_parts.append(str(page['adaptor']))
+
+    if not prefix_parts:
+        return content
+
+    prefix = f"[pg:{'/'.join(prefix_parts)}]"
+    return f"{prefix} {content}"

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -141,6 +141,7 @@ prompts:
     2. Each subsequent job should connect to the previous job with one condition_type: on_job_success, on_job_failure, always or js_expression (for the latter, also add a condition_expression in quotes e.g. '!state.error')
     3. For branching workflows, create conditional edges as appropriate
     4. Edges should be enabled by default
+    5. Edges execute simultaneously and independently. When multiple edges target the same job (e.g., job-3 receives edges from both job-1 and job-2), that target job will run once per incoming edge. If job-1 and job-2 both succeed, job-3 executes twice—once triggered by each edge. This is not a merge or wait operation; each edge fires its target independently when its condition is met.
 
     ## Do NOT fill in job code
 

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -15,6 +15,10 @@ prompts:
 
     When describing your overall purpose to the user, use simple language and explain your task is to help them create an OpenFn workflow. Avoid mentioning YAMLs, as the user does not see the YAML, but a chart drawn based on it.
 
+    Earlier turns may have pertained to different context (specific YAML or job code that is no longer attached).
+    Any previously generated YAML has been redacted from history. Some turns may have a [pg:...]
+    prefix showing the user's page context at that time.
+
     ## OpenFn Project.yaml Structure
 
     A valid project.yaml must follow this structure:
@@ -102,7 +106,7 @@ prompts:
     ## Do NOT fill in job code
 
     Your task is to create the workflow structure only — do NOT generate job code (i.e., the "body" key in jobs). 
-    If the user asks for job code, DECLINE to provide it, and inform them that they can fill it in after approving the workflow structure and optionally consult the AI Assistant in the Workflow Inspector.
+    If the user asks for job code, DECLINE to provide it, and inform them that they can fill it in after approving the workflow structure and then optionally consult you after navigating to their job code in the Inspector.
 
     ## Output Format
 

--- a/services/workflow_chat/tests/test_utils.py
+++ b/services/workflow_chat/tests/test_utils.py
@@ -96,7 +96,7 @@ def call_workflow_chat_service(service_input):
             pass
 
 
-def make_service_input(existing_yaml, history, content=None, errors=None):
+def make_service_input(existing_yaml, history, content=None, errors=None, context=None, meta=None):
     service_input = {
         "existing_yaml": existing_yaml,
         "history": history
@@ -105,6 +105,10 @@ def make_service_input(existing_yaml, history, content=None, errors=None):
         service_input["content"] = content
     if errors is not None:
         service_input["errors"] = errors
+    if context is not None:
+        service_input["context"] = context
+    if meta is not None:
+        service_input["meta"] = meta
     return service_input
 
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -523,7 +523,7 @@ def main(data_dict: dict) -> dict:
             errors=data.errors,
             history=data.history,
             stream=data.stream,
-            current_page=current_page
+            current_page=current_page,
             read_only=data.read_only
         )
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -18,33 +18,12 @@ from anthropic import (
     InternalServerError,
 )
 import sentry_sdk
-from util import ApolloError, create_logger
+from util import ApolloError, create_logger, add_page_prefix
 from .gen_project_prompt import build_prompt
 from workflow_chat.available_adaptors import get_available_adaptors
 from streaming_util import StreamManager
 
 logger = create_logger("workflow_chat")
-
-
-# Helper function for page navigation
-def add_page_prefix(content: str, page: Optional[dict]) -> str:
-    """Add [pg:...] prefix to message."""
-    if not page:
-        return content
-
-    prefix_parts = []
-    if page.get('type'):
-        prefix_parts.append(str(page['type']))
-    if page.get('name'):
-        prefix_parts.append(str(page['name']))
-    if page.get('adaptor'):
-        prefix_parts.append(str(page['adaptor']))
-
-    if not prefix_parts:
-        return content
-
-    prefix = f"[pg:{'/'.join(prefix_parts)}]"
-    return f"{prefix} {content}"
 
 
 @dataclass
@@ -216,7 +195,7 @@ class AnthropicClient:
 
                     updated_history = history + [
                         {"role": "user", "content": prefixed_content},
-                        {"role": "assistant", "content": response},
+                        {"role": "assistant", "content": response_text},
                     ]
 
                     stream_manager.end_stream()

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -26,27 +26,6 @@ from streaming_util import StreamManager
 logger = create_logger("workflow_chat")
 
 
-# Schema for structured output
-WORKFLOW_CHAT_OUTPUT_SCHEMA = {
-    "type": "json_schema",
-    "schema": {
-        "type": "object",
-        "properties": {
-            "text": {
-                "type": "string",
-                "description": "Conversational explanation or response to user"
-            },
-            "yaml": {
-                "type": ["string", "null"],
-                "description": "YAML workflow definition, or null if no workflow to generate"
-            }
-        },
-        "required": ["text", "yaml"],
-        "additionalProperties": False
-    }
-}
-
-
 # Helper function for page navigation
 def add_page_prefix(content: str, page: Optional[dict]) -> str:
     """Add [pg:...] prefix to message."""
@@ -158,6 +137,9 @@ class AnthropicClient:
                     history=history
                 )
 
+            # Add prefilled opening brace for JSON response
+            prompt.append({"role": "assistant", "content": '{\n  "text": "'})
+
             accumulated_usage = {
                 "cache_creation_input_tokens": 0,
                 "cache_read_input_tokens": 0,
@@ -175,14 +157,12 @@ class AnthropicClient:
                         text_complete = False
                         sent_length = 0
                         accumulated_response = ""
-                                            
-                        with self.client.beta.messages.stream(
+
+                        with self.client.messages.stream(
                             max_tokens=self.config.max_tokens,
                             messages=prompt,
                             model=self.config.model,
-                            system=system_message,
-                            betas=["structured-outputs-2025-11-13"],
-                            output_format=WORKFLOW_CHAT_OUTPUT_SCHEMA
+                            system=system_message
                         ) as stream_obj:
                             for event in stream_obj:
                                 accumulated_response, text_complete, sent_length = self.process_stream_event(
@@ -202,13 +182,8 @@ class AnthropicClient:
 
                     else:
                         logger.info("Making non-streaming API call")
-                        message = self.client.beta.messages.create(
-                            max_tokens=self.config.max_tokens,
-                            messages=prompt,
-                            model=self.config.model,
-                            system=system_message,
-                            betas=["structured-outputs-2025-11-13"],
-                            output_format=WORKFLOW_CHAT_OUTPUT_SCHEMA
+                        message = self.client.messages.create(
+                            max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message
                         )
 
                 # Track usage from this attempt
@@ -220,10 +195,15 @@ class AnthropicClient:
 
                 response_parts = []
                 for content_block in message.content:
-                    if content_block.type == "text" and content_block.text is not None:
+                    if content_block.type == "text":
                         response_parts.append(content_block.text)
+                    else:
+                        logger.warning(f"Unhandled content type: {content_block.type}")
 
                 response = "\n\n".join(response_parts)
+
+                # Add back the prefilled opening brace
+                response = '{\n  "text": "' + response
 
                 with sentry_sdk.start_span(description="parse_and_format_yaml"):
 
@@ -236,7 +216,7 @@ class AnthropicClient:
 
                     updated_history = history + [
                         {"role": "user", "content": prefixed_content},
-                        {"role": "assistant", "content": response_text},
+                        {"role": "assistant", "content": response},
                     ]
 
                     stream_manager.end_stream()


### PR DESCRIPTION
## Short Description

Added clarification to the workflow_chat prompt explaining that edges execute independently and simultaneously. When multiple edges target the same job, that job runs once per incoming edge rather than waiting for all parent jobs to complete and merging their state. This fixes incorrect model explanations of workflows where parallel jobs converge to a single downstream step.

I tested with Taylor's input in the issue and this seems to work. 

Fixes #352

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
