### PR TITLE
Fix DB issue

### DIFF
--- a/.changeset/shy-beans-raise.md
+++ b/.changeset/shy-beans-raise.md
@@ -1,5 +1,0 @@
----
-"apollo": patch
----
-
-Ensure db tables are checked before adaptors are uploaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # apollo
 
+## 0.19.2
+
+### Patch Changes
+
+- 27fda5b: Ensure db tables are checked before adaptors are uploaded
+
 ## 0.19.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",


### PR DESCRIPTION
Apollo will check that the `adaptor_docs` table exists before it uploads new adaptor docs.

The check runs in `process_adaptor_docs`, which runs just before we insert.

But this check doesn't run on `check_existing_docs`, which happens at the start of load.

The existing call happens in `process_adaptor_docs`, which is only called from `load_adaptor_docs`. By running the check once, at the top of the load function, we should cover ourselves safely

This  closes a bunch of sentry errors and https://github.com/OpenFn/apollo/issues/367