### PR TITLE
Ask workflow agent to refer to unified agent

### DIFF
--- a/.changeset/all-chairs-join.md
+++ b/.changeset/all-chairs-join.md
@@ -1,6 +1,0 @@
----
-"apollo": patch
----
-
-workflow_chat: don't refer to a seperate AI assistant when asked to write job
-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # apollo
 
+## 0.19.4
+
+### Patch Changes
+
+- bd2c51b: workflow_chat: don't refer to a seperate AI assistant when asked to
+  write job code
+
 ## 0.19.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",


### PR DESCRIPTION
## Short Description

Remove reference to a separate job code assistant when instructing the workflow assistant to ask the user to navigate to the job code inspector.

Fixes #364 

## Implementation Details

I've kept the prompt firm and asked the assistant to decline providing job code because we really don't want it to agree to provide it in a follow up conversation turn.

Before:
"I can help you write that job code, but since you’re now looking at the specific job implementation, you should use the AI Assistant in the Workflow Inspector (available when viewing your job code) for help with writing the operations. Would you like me to help with anything else about the workflow structure itself?"

Examples of answers now:
 "I can't generate job code from this view. To write the code for each job, you'll need to save this workflow first, then navigate to the specific job's code page in the Inspector. Once you're on a job's code page, I'll be able to help you write the operations for that step (and see any existing code)."

"I can't generate the job code directly here. To get help with the code, you'll need to save this workflow first, then navigate to each specific job's code page in the Inspector. Once you're viewing a job's code editor, I'll be able to see any existing code and help you write the operations for that specific job."

"I can't generate job code yet. You'll need to save this workflow first, then navigate to each specific job's code page in the Inspector. Once you're on a job's code page, I'll be able to see the job context and help you write the appropriate operations for parsing/aggregating the data and uploading to Redis."


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
