### PR TITLE
Add lightweight router to global agent

### DIFF
--- a/services/global_agent/config.yaml
+++ b/services/global_agent/config.yaml
@@ -1,7 +1,14 @@
-# Global agent supervisor configuration
-model: "claude-sonnet-4-20250514"
-max_tokens: 8192
-temperature: 1.0
+# Global agent configuration
 
-# Tool calling (for iteration 2)
-max_tool_calls: 10
+# Router configuration (lightweight routing)
+router:
+  model: "claude-haiku-4-5-20251001"
+  max_tokens: 500
+  temperature: 0.0
+
+# Planner configuration (complex orchestration)
+planner:
+  model: "claude-sonnet-4-20250514"
+  max_tokens: 8192
+  temperature: 1.0
+  max_tool_calls: 10

--- a/services/global_agent/prompts.yaml
+++ b/services/global_agent/prompts.yaml
@@ -1,7 +1,46 @@
 prompts_version: 1.0.0
 prompts:
-  supervisor_system_prompt: |
+  router_system_prompt: |
+    You are a routing agent for OpenFn. Route requests to the right handler.
+
+    Destinations:
+    - workflow_agent: Workflow YAML (triggers, jobs, edges)
+    - job_code_agent: Job code (JavaScript, adaptor functions)
+    - planner: Complex requests needing BOTH or multiple steps
+
+    You'll receive:
+    - User's current request
+    - Last 2 conversation turns (for context)
+    - Full YAML content (if attached)
+    - Full job code (if attached)
+    - Current page and adaptor info
+
+    Context clues:
+    - YAML attached → likely workflow_agent
+    - Job code attached → likely job_code_agent
+    - Both attached → check what user is asking about
+    - Errors present → usually workflow_agent (workflow errors)
+
+    Response format (JSON only, no explanation):
+    {
+      "destination": "workflow_agent"|"job_code_agent"|"planner",
+      "confidence": 1-5
+    }
+
+    IMPORTANT: Return ONLY the JSON object above. Do not add any explanation or reasoning.
+
+    Route to planner if:
+    - Needs both workflow AND job code
+    - Multiple sequential operations
+    - Unclear/ambiguous request
+
+    Otherwise choose workflow_agent or job_code_agent based on what user wants.
+    Be decisive - most requests are straightforward.
+
+  planner_system_prompt: |
     You are an OpenFn assistant helping users with workflows and job code.
+    Your primary task is to leverage the tools available to you to help the user with their request.
+    Rarely, if the user's request is not clear, you may need to rephrase it or ask for more information.
 
     ## OpenFn Concepts (Brief)
     - **Workflows**: High-level orchestration (YAML) defining triggers, jobs, and execution flow
@@ -13,6 +52,41 @@ prompts:
     1. **search_documentation**: Find information about OpenFn features, adaptors, concepts
     2. **call_workflow_agent**: Create/modify workflows (YAML structure)
     3. **call_job_code_agent**: Help with job code (JavaScript expressions, adaptor functions)
+
+    ## Attached Artifacts & Your Role
+
+    You act as a **project manager/coordinator**, not a code reviewer. When users attach files or context,
+    you'll receive indicators but NOT the full content:
+
+    - **existing_yaml** parameter present → Workflow YAML is attached
+    - **errors** parameter present → Error messages are attached
+    - **context** parameter present → Job code is attached (current code being worked on)
+
+    **CRITICAL**: These artifacts are automatically passed to the appropriate subagents when you call them.
+    You don't need to see the full content - just coordinate and delegate.
+
+    ### When Artifacts Are Attached - DO NOT Ask for Them
+
+    If indicators show artifacts are attached, NEVER ask the user to share what's already there:
+
+    ❌ "I need to see your current job code to help you"
+    ❌ "Please share your workflow YAML so I can modify it"
+    ❌ "Can you show me what you have so far?"
+    ❌ "I'll need to see your code first"
+    ❌ "Could you provide your existing workflow?"
+
+    Instead, acknowledge and delegate directly:
+
+    ✅ "I'll add webhook verification and error handling to your job code"
+    ✅ "Let me modify your workflow to include that trigger"
+    ✅ "I'll update your workflow to add those jobs"
+    ✅ "I'll help you fix that error in your code"
+
+    The appropriate subagent (workflow_agent or job_code_agent) will automatically receive:
+    - workflow_agent gets: existing_yaml, errors
+    - job_code_agent gets: context (job code)
+
+    Trust that if something is genuinely missing, the subagent will ask for it.
 
     ## Guidelines
 
@@ -27,9 +101,6 @@ prompts:
     - When calling workflow_agent, describe changes; YAML is handled automatically
     - Never include YAML in your messages to tools
 
-    ### Message Modes
-    - **pass_through**: User's request is clear (saves tokens)
-    - **custom_message**: Need to rephrase/add context
 
     ### Response Style
     CRITICAL: Never mention "subagents", "calling tools", or internal mechanics. Respond as if you

--- a/services/global_agent/router.py
+++ b/services/global_agent/router.py
@@ -1,0 +1,407 @@
+"""
+Router Agent - Lightweight routing for global agent requests.
+
+Routes requests to workflow_chat, job_chat, or planner based on user intent.
+"""
+import os
+import json
+import time
+from typing import List, Dict, Optional
+from dataclasses import dataclass
+from anthropic import Anthropic
+
+# Import utilities from parent services directory
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent.parent))
+
+from util import create_logger, ApolloError, sum_usage
+from global_agent.config_loader import ConfigLoader
+
+logger = create_logger(__name__)
+
+
+@dataclass
+class RouterDecision:
+    """Decision from router about where to send the request."""
+    destination: str  # "workflow_agent" | "job_code_agent" | "planner"
+    confidence: int   # 1-5, where 5 is highest confidence
+
+
+@dataclass
+class RouterResult:
+    """Result from router or passthrough."""
+    response: str
+    response_yaml: Optional[str]
+    suggested_code: Optional[str]
+    history: List[Dict]
+    usage: Dict
+    meta: Dict
+
+
+class RouterAgent:
+    """
+    Lightweight routing agent using Claude Haiku.
+
+    Routes requests to:
+    - workflow_chat (for workflow YAML)
+    - job_chat (for job code)
+    - planner (for complex multi-step tasks)
+    """
+
+    def __init__(self, config_loader: ConfigLoader, api_key: Optional[str] = None):
+        """
+        Initialize router agent.
+
+        Args:
+            config_loader: Configuration loader instance
+            api_key: Optional API key override
+        """
+        self.config_loader = config_loader
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+
+        if not self.api_key:
+            raise ApolloError(500, "ANTHROPIC_API_KEY not found")
+
+        self.client = Anthropic(api_key=self.api_key)
+
+        # Get router config
+        router_config = config_loader.config.get("router", {})
+        self.model = router_config.get("model", "claude-haiku-4-5-20251001")
+        self.max_tokens = router_config.get("max_tokens", 500)
+        self.temperature = router_config.get("temperature", 0.0)
+
+        logger.info(f"RouterAgent initialized with model: {self.model}")
+
+    def route_and_execute(
+        self,
+        content: str,
+        existing_yaml: Optional[str],
+        errors: Optional[str],
+        context: Optional[Dict],
+        history: List[Dict],
+        read_only: bool,
+        stream: bool
+    ) -> RouterResult:
+        """
+        Route request to appropriate handler and execute.
+
+        Args:
+            content: User message
+            existing_yaml: YAML workflow (as string)
+            errors: Error context
+            context: Job code context (with expression, page_name, adaptor)
+            history: Conversation history
+            read_only: Read-only mode flag
+            stream: Streaming flag
+
+        Returns:
+            RouterResult with response, YAML, code, history, usage, meta
+        """
+        logger.info("Router.route_and_execute() called")
+        start_time = time.time()
+
+        # Make routing decision
+        routing_start = time.time()
+        try:
+            decision = self._make_routing_decision(content, existing_yaml, errors, context, history)
+            routing_time = time.time() - routing_start
+            logger.info(f"Router decision: {decision.destination} (confidence: {decision.confidence}) [took {routing_time:.2f}s]")
+        except Exception as e:
+            routing_time = time.time() - routing_start
+            logger.warning(f"Routing decision failed: {e}. Defaulting to planner for safety. [took {routing_time:.2f}s]")
+            decision = RouterDecision(destination="planner", confidence=1)
+
+        # Execute based on decision
+        if decision.destination == "workflow_agent":
+            result = self._route_to_workflow_chat(
+                content, existing_yaml, errors, history, read_only, stream, decision.confidence
+            )
+        elif decision.destination == "job_code_agent":
+            result = self._route_to_job_chat(
+                content, context, history, stream, decision.confidence
+            )
+        else:  # planner
+            result = self._route_to_planner(
+                content, existing_yaml, errors, context, history, read_only, stream, decision.confidence
+            )
+
+        total_time = time.time() - start_time
+        logger.info(f"Total router took {total_time:.2f}s")
+
+        return result
+
+    def _make_routing_decision(
+        self,
+        content: str,
+        existing_yaml: Optional[str],
+        errors: Optional[str],
+        context: Optional[Dict],
+        history: List[Dict]
+    ) -> RouterDecision:
+        """
+        Make routing decision using Claude Haiku.
+
+        Args:
+            content: User message
+            existing_yaml: YAML workflow
+            errors: Error context
+            context: Job code context
+            history: Conversation history
+
+        Returns:
+            RouterDecision with destination and confidence
+        """
+        # Build routing message with context
+        routing_message = self._build_routing_message(content, existing_yaml, errors, context, history)
+
+        # Get system prompt
+        system_prompt = self.config_loader.get_prompt("router_system_prompt")
+
+        # Call Haiku with prefilled response
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            system=[{"type": "text", "text": system_prompt}],
+            messages=[
+                {"role": "user", "content": routing_message},
+                {"role": "assistant", "content": '{"destination": "'}  # Prefill to constrain format
+            ]
+        )
+
+        # Store routing usage for aggregation
+        self.routing_usage = {
+            "input_tokens": response.usage.input_tokens,
+            "output_tokens": response.usage.output_tokens,
+            "cache_creation_input_tokens": getattr(response.usage, "cache_creation_input_tokens", 0),
+            "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0)
+        }
+
+        # Parse response - prepend the prefilled part back
+        response_text = response.content[0].text if response.content else ""
+        full_response = '{"destination": "' + response_text
+
+        try:
+            # Find the closing brace to extract just the JSON object
+            # Handle case where LLM adds explanation after JSON
+            brace_count = 1
+            json_end = 0
+            for i, char in enumerate(full_response[1:], 1):  # Start after opening brace
+                if char == '{':
+                    brace_count += 1
+                elif char == '}':
+                    brace_count -= 1
+                    if brace_count == 0:
+                        json_end = i + 1
+                        break
+
+            if json_end > 0:
+                json_only = full_response[:json_end]
+            else:
+                json_only = full_response
+
+            decision_data = json.loads(json_only)
+            return RouterDecision(
+                destination=decision_data["destination"],
+                confidence=decision_data.get("confidence", 3)
+            )
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"Failed to parse routing decision: {e}. Response: {full_response}")
+            raise
+
+    def _build_routing_message(
+        self,
+        content: str,
+        existing_yaml: Optional[str],
+        errors: Optional[str],
+        context: Optional[Dict],
+        history: List[Dict]
+    ) -> str:
+        """
+        Build message for routing decision with relevant context.
+
+        Args:
+            content: User message
+            existing_yaml: YAML workflow
+            errors: Error context
+            context: Job code context
+            history: Conversation history
+
+        Returns:
+            Formatted routing message string
+        """
+        parts = []
+
+        # Current user request
+        parts.append(f"User request: {content}")
+
+        # Last 2 turns for context
+        if history and len(history) >= 2:
+            recent_history = history[-2:]
+            parts.append("\nRecent conversation:")
+            for turn in recent_history:
+                role = turn.get("role", "unknown")
+                msg = turn.get("content", "")[:200]  # Truncate long messages
+                parts.append(f"  {role}: {msg}")
+
+        # Attachments (full content for accurate routing)
+        if existing_yaml:
+            parts.append(f"\n[YAML attached, length: {len(existing_yaml)} chars]")
+            parts.append(f"YAML content:\n{existing_yaml}")
+
+        if context and context.get("expression"):
+            job_code = context["expression"]
+            parts.append(f"\n[Job code attached, length: {len(job_code)} chars]")
+            parts.append(f"Job code:\n{job_code}")
+
+        if errors:
+            parts.append(f"\nErrors: {errors}")
+
+        # Page context
+        if context:
+            if context.get("page_name"):
+                parts.append(f"\nCurrent page: {context['page_name']}")
+            if context.get("adaptor"):
+                parts.append(f"Adaptor: {context['adaptor']}")
+
+        return "\n".join(parts)
+
+    def _route_to_workflow_chat(
+        self,
+        content: str,
+        existing_yaml: Optional[str],
+        errors: Optional[str],
+        history: List[Dict],
+        read_only: bool,
+        stream: bool,
+        confidence: int
+    ) -> RouterResult:
+        """Route directly to workflow_chat (called when decision is 'workflow_agent')."""
+        from workflow_chat.workflow_chat import main as workflow_chat_main
+
+        logger.info("Routing to workflow_chat")
+        start_time = time.time()
+
+        payload = {
+            "content": content,
+            "existing_yaml": existing_yaml,
+            "errors": errors,
+            "history": history,
+            "read_only": read_only,
+            "stream": stream
+        }
+
+        # Call service directly - let ApolloError propagate if service fails
+        result = workflow_chat_main(payload)
+        elapsed = time.time() - start_time
+        logger.info(f"workflow_chat took {elapsed:.2f}s")
+
+        # Aggregate token usage
+        total_usage = sum_usage(self.routing_usage, result["usage"])
+
+        # Return as RouterResult with metadata
+        return RouterResult(
+            response=result["response"],
+            response_yaml=result.get("response_yaml"),
+            suggested_code=None,
+            history=result["history"],
+            usage=total_usage,
+            meta={
+                "router_decision": "workflow_agent",
+                "router_confidence": confidence,
+                "direct_passthrough": True
+            }
+        )
+
+    def _route_to_job_chat(
+        self,
+        content: str,
+        context: Optional[Dict],
+        history: List[Dict],
+        stream: bool,
+        confidence: int
+    ) -> RouterResult:
+        """Route directly to job_chat (called when decision is 'job_code_agent')."""
+        from job_chat.job_chat import main as job_chat_main
+
+        logger.info("Routing to job_chat")
+        start_time = time.time()
+
+        payload = {
+            "content": content,
+            "context": context or {},
+            "suggest_code": True,
+            "history": history,
+            "stream": stream
+        }
+
+        # Call service directly - let ApolloError propagate if service fails
+        result = job_chat_main(payload)
+        elapsed = time.time() - start_time
+        logger.info(f"job_chat took {elapsed:.2f}s")
+
+        # Aggregate token usage
+        total_usage = sum_usage(self.routing_usage, result["usage"])
+
+        # Return as RouterResult with metadata
+        return RouterResult(
+            response=result["response"],
+            response_yaml=None,
+            suggested_code=result.get("suggested_code"),
+            history=result["history"],
+            usage=total_usage,
+            meta={
+                **result.get("meta", {}),
+                "router_decision": "job_code_agent",
+                "router_confidence": confidence,
+                "direct_passthrough": True
+            }
+        )
+
+    def _route_to_planner(
+        self,
+        content: str,
+        existing_yaml: Optional[str],
+        errors: Optional[str],
+        context: Optional[Dict],
+        history: List[Dict],
+        read_only: bool,
+        stream: bool,
+        confidence: int
+    ) -> RouterResult:
+        """Delegate to PlannerAgent for complex orchestration."""
+        from global_agent.planner import PlannerAgent
+
+        logger.info("Routing to planner")
+        start_time = time.time()
+
+        planner = PlannerAgent(self.config_loader, self.api_key)
+        planner_result = planner.run(
+            content=content,
+            existing_yaml=existing_yaml,
+            errors=errors,
+            context=context,
+            history=history,
+            read_only=read_only,
+            stream=stream
+        )
+        elapsed = time.time() - start_time
+        logger.info(f"planner took {elapsed:.2f}s")
+
+        # Aggregate token usage
+        total_usage = sum_usage(self.routing_usage, planner_result.usage)
+
+        # Convert to RouterResult
+        return RouterResult(
+            response=planner_result.response,
+            response_yaml=planner_result.response_yaml,
+            suggested_code=planner_result.suggested_code,
+            history=planner_result.history,
+            usage=total_usage,
+            meta={
+                **planner_result.meta,
+                "router_decision": "planner",
+                "router_confidence": confidence
+            }
+        )

--- a/services/global_agent/subagent_caller.py
+++ b/services/global_agent/subagent_caller.py
@@ -20,7 +20,6 @@ def call_workflow_agent(
     tool_input: Dict,
     existing_yaml: Optional[str],
     errors: Optional[str],
-    history: List[Dict],
     read_only: bool
 ) -> Dict:
     """
@@ -76,14 +75,14 @@ def call_workflow_agent(
 
 def call_job_agent(
     tool_input: Dict,
-    history: List[Dict]
+    context: Dict = None
 ) -> Dict:
     """
     Call the job code agent and return its results.
 
     Args:
-        tool_input: Tool input from supervisor containing mode, message
-        history: Conversation history
+        tool_input: Tool input from supervisor containing message
+        context: Job code context (current code being worked on)
 
     Returns:
         Dictionary with job agent response (raw, not formatted)
@@ -97,7 +96,7 @@ def call_job_agent(
     # Build job agent payload
     job_payload = {
         "content": user_message,
-        "context": {},
+        "context": context or {},
         "suggest_code": True,
         "stream": False,
         "history": []  # Supervisor includes context in message

--- a/services/global_agent/tools/tool_definitions.py
+++ b/services/global_agent/tools/tool_definitions.py
@@ -8,8 +8,7 @@ These are Claude API tool schemas that define what tools are available.
 SEARCH_DOCUMENTATION_TOOL = {
     "name": "search_documentation",
     "description": """Search OpenFn documentation using semantic similarity.
-Use this when you need to find information about OpenFn adaptors, functions,
-or workflow concepts to help answer the user's question.""",
+Use this when you need to find general information about OpenFn and its automation concepts to help answer the user's question.""",
     "input_schema": {
         "type": "object",
         "properties": {
@@ -33,8 +32,8 @@ CALL_WORKFLOW_AGENT_TOOL = {
     "description": """Create or modify OpenFn workflows (YAML).
 
 Use this tool when the user wants to:
-- Generate a new workflow from scratch
-- Add jobs, steps, or triggers to an existing workflow
+- Do anything related to workflows
+- Add jobs, steps, or triggers to an existing workflow or create a new workflow from scratch
 - Modify workflow structure or configuration
 - Debug or fix workflow YAML errors
 


### PR DESCRIPTION
## Short Description

Makes the supervisor into a specialised planner agent for complex tasks, and adds a lightweight router to pass messages to the right agent. This solves problems with speed and the supervisor's insistence in reformulating answers. We can still achieve complex multi-step tasks by occasionally calling the planner agent. This solution is better suited for our case where we are not trying to solve any given coding problem (like Claude Code etc) but a more defined set of tasks (OpenFn tasks).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
