### PR TITLE
Feed API key from global chat to sub-agents

### DIFF
--- a/.changeset/red-clubs-go.md
+++ b/.changeset/red-clubs-go.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+pass global agent api key to subagents

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -242,7 +242,8 @@ class PlannerAgent:
         elif tool_use_block.name == "call_workflow_agent":
             subagent_result = call_workflow_agent(
                 tool_use_block.input,
-                workflow_yaml=self.current_yaml
+                workflow_yaml=self.current_yaml,
+                api_key=self.api_key
             )
 
             if "usage" in subagent_result:
@@ -283,7 +284,8 @@ class PlannerAgent:
 
             subagent_result = call_job_agent(
                 tool_use_block.input,
-                workflow_yaml=self.current_yaml
+                workflow_yaml=self.current_yaml,
+                api_key=self.api_key
             )
 
             if "usage" in subagent_result:

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -230,7 +230,8 @@ class RouterAgent:
             "content": enriched_content,
             "existing_yaml": workflow_yaml,
             "history": clean_history,
-            "stream": stream
+            "stream": stream,
+            "api_key": self.api_key
         }
 
         result = workflow_chat_main(payload)
@@ -297,7 +298,8 @@ class RouterAgent:
             "context": job_context,
             "suggest_code": True,
             "history": clean_history,
-            "stream": stream
+            "stream": stream,
+            "api_key": self.api_key
         }
 
         result = job_chat_main(payload)

--- a/services/global_chat/subagent_caller.py
+++ b/services/global_chat/subagent_caller.py
@@ -18,7 +18,8 @@ logger = create_logger(__name__)
 
 def call_workflow_agent(
     tool_input: Dict,
-    workflow_yaml: Optional[str] = None
+    workflow_yaml: Optional[str] = None,
+    api_key: Optional[str] = None
 ) -> Dict:
     """
     Call the workflow agent and return its results.
@@ -39,7 +40,8 @@ def call_workflow_agent(
     workflow_payload = {
         "content": user_message,
         "existing_yaml": workflow_yaml,
-        "history": []  # Supervisor includes context in message
+        "history": [],  # Supervisor includes context in message
+        "api_key": api_key
     }
 
     try:
@@ -62,7 +64,8 @@ def call_workflow_agent(
 
 def call_job_agent(
     tool_input: Dict,
-    workflow_yaml: Optional[str] = None
+    workflow_yaml: Optional[str] = None,
+    api_key: Optional[str] = None
 ) -> Dict:
     """
     Call the job code agent and return its results.
@@ -99,7 +102,8 @@ def call_job_agent(
         "context": job_context,
         "suggest_code": True,
         "stream": False,
-        "history": []  # Supervisor includes context in message
+        "history": [],  # Supervisor includes context in message
+        "api_key": api_key
     }
 
     try:


### PR DESCRIPTION
## Short Description

Makes sure api_key from the payload is passed through to subagent calls:

`subagent_caller.py` — Adds api_key param to call_workflow_agent() and call_job_agent(), includes it in the payloads sent to the downstream services
`planner.py` — Passes self.api_key when calling subagent functions
`router.py` — Passes self.api_key in payloads when directly routing to `workflow_chat` and `job_chat`

Fixes #417 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
