### PR TITLE
fix: skip sending null YAML as streaming changes event

### DIFF
--- a/.changeset/empty-oranges-turn.md
+++ b/.changeset/empty-oranges-turn.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+fix empty yaml key handling after streaming order reversal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # apollo
 
+## 0.21.1
+
+### Patch Changes
+
+- workflow_chat: Fix streaming sending "null" as YAML changes event for
+  informational responses (#427)
+
 ## 0.21.0
 
 ### Minor Changes

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -183,14 +183,14 @@ prompts:
 
     The output should be:
     {{
-      "text": "I'd structure this as a daily cron-triggered workflow with four jobs. First, fetch visits from CommCare. Then branch based on whether visitors have IHS numbers: create encounters directly for those who do, or lookup the number first for those who don't. Here's the structure:\n\n```yaml\nname: Daily CommCare to Satusehat Encounter Sync\njobs:\n  Fetch-visits-from-CommCare:\n    name: Fetch visits from CommCare\n    adaptor: \"@openfn/language-commcare@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    name: Create FHIR Encounter for visitors with IHS number\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Lookup-IHS-number-in-Satusehat:\n    name: Lookup IHS number in Satusehat\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-after-IHS-lookup:\n    name: Create FHIR Encounter after IHS lookup\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\ntriggers:\n  cron:\n    type: cron\n    cron_expression: 0 0 * * *\n    enabled: false\nedges:\n  cron->Fetch-visits-from-CommCare:\n    source_trigger: cron\n    target_job: Fetch-visits-from-CommCare\n    condition_type: always\n    enabled: true\n  Fetch-visits-from-CommCare->Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Create-FHIR-Encounter-for-visitors-with-IHS-number\n    condition_type: on_job_success\n    enabled: true\n  Fetch-visits-from-CommCare->Lookup-IHS-number-in-Satusehat:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Lookup-IHS-number-in-Satusehat\n    condition_type: on_job_success\n    enabled: true\n  Lookup-IHS-number-in-Satusehat->Create-FHIR-Encounter-after-IHS-lookup:\n    source_job: Lookup-IHS-number-in-Satusehat\n    target_job: Create-FHIR-Encounter-after-IHS-lookup\n    condition_type: on_job_success\n    enabled: true\n```",
-      "yaml": null
+      "yaml": "",
+      "text": "I'd structure this as a daily cron-triggered workflow with four jobs. First, fetch visits from CommCare. Then branch based on whether visitors have IHS numbers: create encounters directly for those who do, or lookup the number first for those who don't. Here's the structure:\n\n```yaml\nname: Daily CommCare to Satusehat Encounter Sync\njobs:\n  Fetch-visits-from-CommCare:\n    name: Fetch visits from CommCare\n    adaptor: \"@openfn/language-commcare@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    name: Create FHIR Encounter for visitors with IHS number\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Lookup-IHS-number-in-Satusehat:\n    name: Lookup IHS number in Satusehat\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-after-IHS-lookup:\n    name: Create FHIR Encounter after IHS lookup\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\ntriggers:\n  cron:\n    type: cron\n    cron_expression: 0 0 * * *\n    enabled: false\nedges:\n  cron->Fetch-visits-from-CommCare:\n    source_trigger: cron\n    target_job: Fetch-visits-from-CommCare\n    condition_type: always\n    enabled: true\n  Fetch-visits-from-CommCare->Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Create-FHIR-Encounter-for-visitors-with-IHS-number\n    condition_type: on_job_success\n    enabled: true\n  Fetch-visits-from-CommCare->Lookup-IHS-number-in-Satusehat:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Lookup-IHS-number-in-Satusehat\n    condition_type: on_job_success\n    enabled: true\n  Lookup-IHS-number-in-Satusehat->Create-FHIR-Encounter-after-IHS-lookup:\n    source_job: Lookup-IHS-number-in-Satusehat\n    target_job: Create-FHIR-Encounter-after-IHS-lookup\n    condition_type: on_job_success\n    enabled: true\n```"
     }}
 
     ## Output Format
 
     You must respond in JSON format with two fields: "yaml" and "text".
-    The "yaml" field should always be null.
+    The "yaml" field should always be an empty string.
     The "text" field contains your complete answer with any YAML in triple-backticked code blocks.
 
   normal_mode_intro: |
@@ -211,7 +211,7 @@ prompts:
 
   normal_mode_answering_instructions: |
     You can either
-    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as null,
+    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as an empty string,
 
     or
 
@@ -233,13 +233,13 @@ prompts:
 
   readonly_mode_answering_instructions: |
     You can either
-    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as null,
+    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as an empty string,
 
     or
 
     B) answer with your explanation in the "text" key, including any workflow structure inline using triple-backticked YAML code blocks.
     In this case, provide a few sentences (max. as many sentences as there are jobs in the workflow) to explain your reasoning, followed by the YAML in a code block.
     If relevant, you can note aspects of the workflow that should be reviewed (e.g. to consider alternative approaches).
-    Always leave the "yaml" key as null.
+    Always leave the "yaml" key as an empty string.
 
     The user's latest message and prior conversation are provided below. Generate your response accordingly.

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -357,14 +357,17 @@ class AnthropicClient:
                 # Parse YAML string into Python object
                 output_yaml = yaml.safe_load(output_yaml)
 
-                with sentry_sdk.start_span(description="validate_adaptors"):
-                    self.validate_adaptors(output_yaml)
-                with sentry_sdk.start_span(description="sanitize_job_names"):
-                    self.sanitize_job_names(output_yaml)
-                with sentry_sdk.start_span(description="restore_components"):
-                    self.restore_components(output_yaml, preserved_values)
-                # Convert back to YAML string with preserved order
-                output_yaml = yaml.dump(output_yaml, sort_keys=False)
+                if not isinstance(output_yaml, dict):
+                    output_yaml = ""
+                else:
+                    with sentry_sdk.start_span(description="validate_adaptors"):
+                        self.validate_adaptors(output_yaml)
+                    with sentry_sdk.start_span(description="sanitize_job_names"):
+                        self.sanitize_job_names(output_yaml)
+                    with sentry_sdk.start_span(description="restore_components"):
+                        self.restore_components(output_yaml, preserved_values)
+                    # Convert back to YAML string with preserved order
+                    output_yaml = yaml.dump(output_yaml, sort_keys=False)
             else:
                 output_yaml = ""
                 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -159,8 +159,12 @@ class AnthropicClient:
                     read_only=read_only
                 )
 
-            # Add prefilled opening brace for JSON response (yaml first, text second)
-            prompt.append({"role": "assistant", "content": '{\n  "yaml": "'})
+            # Add prefilled opening brace for JSON response
+            if read_only:
+                # In read-only mode, close yaml as empty and start text directly
+                prompt.append({"role": "assistant", "content": '{\n  "yaml": "", "text": "'})
+            else:
+                prompt.append({"role": "assistant", "content": '{\n  "yaml": "'})
 
             accumulated_usage = {
                 "cache_creation_input_tokens": 0,
@@ -176,7 +180,7 @@ class AnthropicClient:
                         logger.info("Making streaming API call")
                         stream_manager.send_thinking("Thinking...")
 
-                        text_started = False
+                        text_started = read_only  # In read-only mode, text starts immediately (no yaml phase)
                         sent_length = 0
                         accumulated_response = ""
 
@@ -225,7 +229,10 @@ class AnthropicClient:
                 response = "\n\n".join(response_parts)
 
                 # Add back the prefilled opening
-                response = '{\n  "yaml": "' + response
+                if read_only:
+                    response = '{\n  "yaml": "", "text": "' + response
+                else:
+                    response = '{\n  "yaml": "' + response
 
                 with sentry_sdk.start_span(description="parse_and_format_yaml"):
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -513,7 +513,7 @@ class AnthropicClient:
                         # yaml_raw is the string content between the prefilled opening " and delimiter "
                         yaml_raw = accumulated_response.split(delimiter)[0]
                         yaml_value = self._unescape_json_string(yaml_raw)
-                        if yaml_value:
+                        if yaml_value and yaml_value != "null":
                             stream_manager.send_changes({"yaml": yaml_value})
 
                         # Mark where text content starts


### PR DESCRIPTION
## Short Description

Skip sending "null" as a YAML streaming changes event when the model returns no workflow changes.

Fixes #427

## Implementation Details

When the model returns `{"yaml": null, "text": "..."}` for informational responses (e.g. simple greetings), the streaming code unescapes JSON `null` into the string `"null"` via `_unescape_json_string`. This truthy string passes the `if yaml_value:` check and gets sent as a `changes` event, causing the frontend to display "null" as generated workflow code with an Apply button.

The fix adds a check that `yaml_value != "null"` before sending the `changes` event. This specifically handles the semantic mismatch where JSON `null` becomes the truthy string `"null"` through the unescaping step.

## AI Usage

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI