### PR TITLE
feat: router outputs target job_key when routing to job_code_agent

### DIFF
--- a/services/global_chat/PAYLOAD_SPEC.md
+++ b/services/global_chat/PAYLOAD_SPEC.md
@@ -118,7 +118,7 @@ This document defines the input and output payload structure for the Global Agen
 
 - **`response`** (string): The main text response from the agent.
 
-- **`attachments`** (array): Artifacts produced during this turn. Each entry has a `type` and `content` field. An empty list `[]` means no artifacts were produced (e.g. a purely informational response). Currently supported types: `workflow_yaml`.
+- **`attachments`** (array): Artifacts produced during this turn. Each entry has a `type` and `content` field. An empty list `[]` means no artifacts were produced (e.g. a purely informational response). Currently supported types: `workflow_yaml`, `job_code`. When both are present, `job_code` contains the suggested code for a specific job and `workflow_yaml` contains the full YAML with the code stitched in.
 
 - **`history`** (array): Updated conversation history including the latest exchange. On direct routes (workflow_agent, job_code_agent), each entry has `content` as a string. On the planner path, entries may have `content` as an array of content blocks (`text`, `tool_use`, `tool_result`) — this is the raw Anthropic messages format from the tool-calling loop.
 

--- a/services/global_chat/prompts.yaml
+++ b/services/global_chat/prompts.yaml
@@ -23,7 +23,8 @@ prompts:
     Response format (JSON only, no explanation):
     {
       "destination": "workflow_agent"|"job_code_agent"|"planner",
-      "confidence": 1-5
+      "confidence": 1-5,
+      "job_key": "job-key-from-yaml" // REQUIRED when destination is job_code_agent. Must match a job key from the workflow YAML.
     }
 
     IMPORTANT: Return ONLY the JSON object above. Do not add any explanation or reasoning.

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -319,7 +319,10 @@ class RouterAgent:
 
         attachments = []
         if result.get("suggested_code"):
-            attachments.append({"type": "job_code", "content": result["suggested_code"]})
+            job_code_attachment = {"type": "job_code", "content": result["suggested_code"]}
+            if matched_job_key:
+                job_code_attachment["job_key"] = matched_job_key
+            attachments.append(job_code_attachment)
         if updated_yaml:
             attachments.append({"type": "workflow_yaml", "content": updated_yaml})
 

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -27,6 +27,7 @@ class RouterDecision:
     """Decision from router about where to send the request."""
     destination: str  # "workflow_agent" | "job_code_agent" | "planner"
     confidence: int   # 1-5, where 5 is highest confidence
+    job_key: Optional[str] = None  # Target job key when routing to job_code_agent
 
 
 @dataclass
@@ -101,7 +102,7 @@ class RouterAgent:
 
         try:
             decision = self._make_routing_decision(content, workflow_yaml, page, history)
-            logger.info(f"Router decision: {decision.destination} (confidence: {decision.confidence})")
+            logger.info(f"Router decision: {decision.destination} (confidence: {decision.confidence}, job_key: {decision.job_key})")
         except Exception as e:
             logger.warning(f"Routing decision failed: {e}. Defaulting to planner for safety.")
             decision = RouterDecision(destination="planner", confidence=1)
@@ -109,7 +110,7 @@ class RouterAgent:
         if decision.destination == "workflow_agent":
             result = self._route_to_workflow_chat(content, workflow_yaml, history, stream, decision.confidence)
         elif decision.destination == "job_code_agent":
-            result = self._route_to_job_chat(content, workflow_yaml, page, history, stream, decision.confidence)
+            result = self._route_to_job_chat(content, workflow_yaml, page, history, stream, decision.confidence, decision.job_key)
         else:
             result = self._route_to_planner(content, workflow_yaml, page, history, stream, decision.confidence)
 
@@ -163,7 +164,8 @@ class RouterAgent:
             decision_data = json.loads(json_only)
             return RouterDecision(
                 destination=decision_data["destination"],
-                confidence=decision_data.get("confidence", 3)
+                confidence=decision_data.get("confidence", 3),
+                job_key=decision_data.get("job_key")
             )
         except (json.JSONDecodeError, KeyError) as e:
             logger.error(f"Failed to parse routing decision: {e}. Response: {full_response}")
@@ -260,24 +262,27 @@ class RouterAgent:
         page: Optional[str],
         history: List[Dict],
         stream: bool,
-        confidence: int
+        confidence: int,
+        router_job_key: Optional[str] = None
     ) -> RouterResult:
         """
         Route directly to job_chat.
 
         Extracts the focused job's code and adaptor from the workflow YAML using
-        the step name parsed from the page URL, then stitches the suggested code
-        back into the workflow YAML before returning.
+        the step name parsed from the page URL (or the router's job_key as
+        fallback), then stitches the suggested code back into the workflow YAML
+        before returning.
         """
         from job_chat.job_chat import main as job_chat_main
 
         logger.info("Routing to job_chat")
 
-        # Build job context from YAML using step name from page
+        # Build job context from YAML using step name from page,
+        # falling back to the router's job_key decision
         job_context = {}
         matched_job_key = None
 
-        step_name = get_step_name_from_page(page)
+        step_name = get_step_name_from_page(page) or router_job_key
         if workflow_yaml and step_name:
             matched_job_key, job_data = find_job_in_yaml(workflow_yaml, step_name)
             if matched_job_key is None:

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -318,6 +318,8 @@ class RouterAgent:
             logger.warning(f"suggested_code generated but no job matched for page '{page}' - YAML not updated")
 
         attachments = []
+        if result.get("suggested_code"):
+            attachments.append({"type": "job_code", "content": result["suggested_code"]})
         if updated_yaml:
             attachments.append({"type": "workflow_yaml", "content": updated_yaml})
 


### PR DESCRIPTION
## Short Description

When routing to job_code_agent, the router now also outputs the target job_key so that job code changes work even when the user is on the workflow overview (no step name in the page URL).

Fixes #428

## Implementation Details

When the user is on the workflow overview and asks the global assistant to modify job code, the router correctly identifies the request as a job_code_agent task. However, `_route_to_job_chat` relies on the `page` URL to identify which job to extract context from and stitch code back into. Without a step name in the URL, `matched_job_key` stays `None` and code stitching silently fails.

The router LLM already sees the full YAML and user message to make the routing decision. This PR extends it to also output the target `job_key` (matching a key from the workflow YAML) when routing to `job_code_agent`.

Changes:
- Add optional `job_key` field to `RouterDecision`
- Update routing prompt to require `job_key` when destination is `job_code_agent`
- Parse `job_key` from LLM response
- `_route_to_job_chat` falls back to `router_job_key` when `get_step_name_from_page` returns nothing

## AI Usage

- [ ] Code generation (copilot but not intellisense)
- [ ] Strategy / design
- [ ] Learning or fact checking
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI