### PR TITLE
feat: return job_code attachment when routing to job_code_agent

### DIFF
--- a/services/global_chat/PAYLOAD_SPEC.md
+++ b/services/global_chat/PAYLOAD_SPEC.md
@@ -118,7 +118,7 @@ This document defines the input and output payload structure for the Global Agen
 
 - **`response`** (string): The main text response from the agent.
 
-- **`attachments`** (array): Artifacts produced during this turn. Each entry has a `type` and `content` field. An empty list `[]` means no artifacts were produced (e.g. a purely informational response). Currently supported types: `workflow_yaml`.
+- **`attachments`** (array): Artifacts produced during this turn. Each entry has a `type` and `content` field. An empty list `[]` means no artifacts were produced (e.g. a purely informational response). Currently supported types: `workflow_yaml`, `job_code`. When both are present, `job_code` contains the suggested code for a specific job and `workflow_yaml` contains the full YAML with the code stitched in.
 
 - **`history`** (array): Updated conversation history including the latest exchange. On direct routes (workflow_agent, job_code_agent), each entry has `content` as a string. On the planner path, entries may have `content` as an array of content blocks (`text`, `tool_use`, `tool_result`) — this is the raw Anthropic messages format from the tool-calling loop.
 

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -319,7 +319,10 @@ class RouterAgent:
 
         attachments = []
         if result.get("suggested_code"):
-            attachments.append({"type": "job_code", "content": result["suggested_code"]})
+            job_code_attachment = {"type": "job_code", "content": result["suggested_code"]}
+            if matched_job_key:
+                job_code_attachment["job_key"] = matched_job_key
+            attachments.append(job_code_attachment)
         if updated_yaml:
             attachments.append({"type": "workflow_yaml", "content": updated_yaml})
 

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -318,6 +318,8 @@ class RouterAgent:
             logger.warning(f"suggested_code generated but no job matched for page '{page}' - YAML not updated")
 
         attachments = []
+        if result.get("suggested_code"):
+            attachments.append({"type": "job_code", "content": result["suggested_code"]})
         if updated_yaml:
             attachments.append({"type": "workflow_yaml", "content": updated_yaml})
 


### PR DESCRIPTION
## Short Description

When the router delegates to job_code_agent, include the suggested code as a separate job_code attachment alongside the workflow_yaml attachment.

Fixes #430

## Implementation Details

When the global chat routes to job_code_agent, the response currently only contains a workflow_yaml attachment (full YAML with code stitched in). The frontend renders this as a "Generated Workflow" YAML card, even when the user is viewing a specific job in the code editor and would expect to see a code diff.

The normal (non-global) job_chat returns suggested_code directly, which the frontend renders as a code diff in Monaco. The global chat was losing this granularity by wrapping everything into workflow_yaml.

Now _route_to_job_chat returns both attachments when suggested_code is available:
- {type: "job_code", content: suggested_code} — for rendering as a code diff
- {type: "workflow_yaml", content: updated_yaml} — for applying to the canvas

The Lightning side can then pick job_code over workflow_yaml for the message code field, so the frontend renders a code diff instead of a YAML card when appropriate.

## AI Usage

- [ ] Code generation (copilot but not intellisense)
- [ ] Strategy / design
- [ ] Learning or fact checking
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI