### PR TITLE
Fix rag model registry usage

### DIFF
--- a/.changeset/fiery-spies-double.md
+++ b/.changeset/fiery-spies-double.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+fix model use in rag

--- a/services/job_chat/Untitled
+++ b/services/job_chat/Untitled
@@ -1,0 +1,1 @@
+fix-null-yaml-streaming-changes

--- a/services/job_chat/rag.yaml
+++ b/services/job_chat/rag.yaml
@@ -1,5 +1,7 @@
 config_version: 1.0
 model: "claude-sonnet"
+llm_search_decision: "claude-sonnet"
+llm_retrieval: "claude-sonnet"
 threshold: 0.8
 top_k: 5
 temperature: 0

--- a/services/job_chat/retrieve_docs.py
+++ b/services/job_chat/retrieve_docs.py
@@ -13,6 +13,7 @@ from anthropic import (
 )
 import sentry_sdk
 from util import ApolloError, create_logger
+from models import resolve_model
 from search_docsite.search_docsite import DocsiteSearch
 from .rag_config_loader import ConfigLoader
 from streaming_util import StreamManager
@@ -106,7 +107,7 @@ def needs_docs(content, client, user_context=""):
     )
     
     response_text, usage = call_llm(
-        model=config["llm_search_decision"],
+        model=resolve_model(config["llm_search_decision"]),
         temperature=config["temperature"],
         system_prompt=config_loader.prompts["prompts"]["needs_docs_system_prompt"],
         user_prompt=formatted_user_prompt,
@@ -124,7 +125,7 @@ def generate_queries(content, client, user_context=""):
     )
 
     text, usage = call_llm(
-        model=config["llm_retrieval"],
+        model=resolve_model(config["llm_retrieval"]),
         temperature=config["temperature"],
         system_prompt=config_loader.prompts["prompts"]["search_docs_system_prompt"],
         user_prompt=formatted_user_prompt,


### PR DESCRIPTION
## Short Description

Restores RAG doc retrieval config keys llm_search_decision and llm_retrieval and wraps them with resolve_model() so the short name "claude-sonnet" is resolved to a full model ID.

Fixes #432

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
