### PR TITLE
Fix empty code key

### DIFF
--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -117,6 +117,7 @@ class PlannerAgent:
                     system=system_prompt,
                     messages=messages,
                     tools=self.tools,
+                    thinking={"type": "adaptive"},
                     betas=["context-management-2025-06-27"],
                     context_management={
                         "edits": [

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -118,6 +118,7 @@ class PlannerAgent:
                     messages=messages,
                     tools=self.tools,
                     thinking={"type": "adaptive"},
+                    output_config={"effort": "high"},
                     betas=["context-management-2025-06-27"],
                     context_management={
                         "edits": [
@@ -142,6 +143,11 @@ class PlannerAgent:
                     total_usage[field] += getattr(response.usage, field, 0)
 
                 logger.info(f"Claude API call {tool_call_count + 1}: stop_reason={response.stop_reason}")
+
+                # Forward any thinking blocks to the client
+                for block in response.content:
+                    if block.type == "thinking":
+                        stream_manager.send_thinking(block.thinking)
 
                 if response.stop_reason == "end_turn":
                     if tool_call_count > 0:
@@ -174,7 +180,13 @@ class PlannerAgent:
 
                     content_blocks = []
                     for block in response.content:
-                        if block.type == "text":
+                        if block.type == "thinking":
+                            content_blocks.append({
+                                "type": "thinking",
+                                "thinking": block.thinking,
+                                "signature": block.signature
+                            })
+                        elif block.type == "text":
                             content_blocks.append({"type": "text", "text": block.text})
                         elif block.type == "tool_use":
                             content_blocks.append({

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -127,15 +127,31 @@ class RouterAgent:
         routing_message = self._build_routing_message(content, workflow_yaml, page, history)
         system_prompt = self.config_loader.get_prompt("router_system_prompt")
 
+        routing_schema = {
+            "type": "object",
+            "properties": {
+                "destination": {"type": "string"},
+                "confidence": {"type": "integer"},
+                "job_key": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"}
+                    ]
+                }
+            },
+            "required": ["destination", "confidence", "job_key"],
+            "additionalProperties": False
+        }
+
         response = self.client.messages.create(
             model=self.model,
             max_tokens=self.max_tokens,
             temperature=self.temperature,
             system=[{"type": "text", "text": system_prompt}],
             messages=[
-                {"role": "user", "content": routing_message},
-                {"role": "assistant", "content": '{"destination": "'}
-            ]
+                {"role": "user", "content": routing_message}
+            ],
+            output_config={"format": {"type": "json_schema", "schema": routing_schema}}
         )
 
         self.routing_usage = {
@@ -145,30 +161,17 @@ class RouterAgent:
             "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0)
         }
 
-        response_text = response.content[0].text if response.content else ""
-        full_response = '{"destination": "' + response_text
+        response_text = response.content[0].text if response.content else "{}"
 
         try:
-            brace_count = 1
-            json_end = 0
-            for i, char in enumerate(full_response[1:], 1):
-                if char == '{':
-                    brace_count += 1
-                elif char == '}':
-                    brace_count -= 1
-                    if brace_count == 0:
-                        json_end = i + 1
-                        break
-
-            json_only = full_response[:json_end] if json_end > 0 else full_response
-            decision_data = json.loads(json_only)
+            decision_data = json.loads(response_text)
             return RouterDecision(
                 destination=decision_data["destination"],
                 confidence=decision_data.get("confidence", 3),
                 job_key=decision_data.get("job_key")
             )
         except (json.JSONDecodeError, KeyError) as e:
-            logger.error(f"Failed to parse routing decision: {e}. Response: {full_response}")
+            logger.error(f"Failed to parse routing decision: {e}. Response: {response_text}")
             raise
 
     def _build_routing_message(

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -208,7 +208,8 @@ class AnthropicClient:
                         max_tokens=self.config.max_tokens,
                         messages=prompt,
                         model=self.config.model,
-                        system=system_message
+                        system=system_message,
+                        thinking={"type": "adaptive"}
                     )
                     if output_config:
                         stream_kwargs["output_config"] = output_config
@@ -238,7 +239,8 @@ class AnthropicClient:
                 else:
                     logger.info("Making non-streaming API call")
                     create_kwargs = dict(
-                        max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message
+                        max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
+                        thinking={"type": "adaptive"}
                     )
                     if output_config:
                         create_kwargs["output_config"] = output_config
@@ -254,8 +256,6 @@ class AnthropicClient:
             for content_block in message.content:
                 if content_block.type == "text":
                     response_parts.append(content_block.text)
-                else:
-                    logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
 
@@ -493,16 +493,26 @@ class AnthropicClient:
                 full_code=full_code,
                 text_explanation=text_explanation
             )
-            prompt.append({"role": "assistant", "content": '{\n  "explanation": "'})
+            correction_schema = {
+                "type": "object",
+                "properties": {
+                    "explanation": {"type": "string"},
+                    "corrected_old_code": {"type": "string"},
+                    "corrected_new_code": {"type": "string"}
+                },
+                "required": ["explanation", "corrected_old_code", "corrected_new_code"],
+                "additionalProperties": False
+            }
             message = self.client.messages.create(
                 max_tokens=16384,
                 messages=prompt,
                 model=self.config.model,
-                system=system_message
+                system=system_message,
+                output_config={"format": {"type": "json_schema", "schema": correction_schema}},
+                thinking={"type": "adaptive"}
             )
 
             response = "\n\n".join([block.text for block in message.content if block.type == "text"])
-            response = '{\n  "explanation": "' + response  # Add back the prefilled opening brace
             correction_data = json.loads(response)
 
             corrected_old = correction_data.get("corrected_old_code")

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -316,9 +316,7 @@ class AnthropicClient:
         then a changes event is sent, and text_answer streams to the client.
         """
         if event.type == "content_block_delta":
-            if event.delta.type == "thinking_delta":
-                stream_manager.send_thinking(event.delta.thinking)
-            elif event.delta.type == "text_delta":
+            if event.delta.type == "text_delta":
                 text_chunk = event.delta.text
                 accumulated_response += text_chunk
 

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 import yaml
 from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
@@ -28,6 +29,29 @@ with open(os.path.join(_dir, "rag.yaml")) as _f:
 _MODEL = resolve_model(_service_config.get("model", "claude-sonnet"))
 
 logger = create_logger("job_chat")
+
+# JSON schema for structured outputs when suggest_code is True
+_CODE_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "code_edits": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string"},
+                    "old_code": {"type": "string"},
+                    "new_code": {"type": "string"}
+                },
+                "required": ["action", "new_code"],
+                "additionalProperties": False
+            }
+        },
+        "text_answer": {"type": "string"}
+    },
+    "required": ["code_edits", "text_answer"],
+    "additionalProperties": False
+}
 
 
 # Helper function for page navigation
@@ -153,7 +177,6 @@ class AnthropicClient:
                         download_adaptor_docs=download_adaptor_docs,
                         refresh_rag=refresh_rag
                     )
-                    prompt.append({"role": "assistant", "content": '{\n  "code_edits": ['})
 
                 else:
                     system_message, prompt, retrieved_knowledge = build_old_prompt(
@@ -166,6 +189,12 @@ class AnthropicClient:
                         refresh_rag=refresh_rag
                         )
 
+            # Structured outputs for suggest_code mode
+            output_config = (
+                {"format": {"type": "json_schema", "schema": _CODE_OUTPUT_SCHEMA}}
+                if suggest_code else None
+            )
+
             with sentry_sdk.start_span(description="anthropic_api_call"):
                 if stream:
                     logger.info("Making streaming API call")
@@ -175,12 +204,16 @@ class AnthropicClient:
 
                     original_code = context.get("expression") if context and isinstance(context, dict) else None
 
-                    with self.client.messages.stream(
+                    stream_kwargs = dict(
                         max_tokens=self.config.max_tokens,
                         messages=prompt,
                         model=self.config.model,
                         system=system_message
-                    ) as stream_obj:
+                    )
+                    if output_config:
+                        stream_kwargs["output_config"] = output_config
+
+                    with self.client.messages.stream(**stream_kwargs) as stream_obj:
                         for event in stream_obj:
                             accumulated_response, text_started, sent_length = self.process_stream_event(
                                 event,
@@ -194,17 +227,22 @@ class AnthropicClient:
                             )
                     message = stream_obj.get_final_message()
 
-                    # Flush any remaining buffered text
+                    # Flush any remaining buffered text, stripping JSON closing chars
                     if suggest_code and text_started:
                         if sent_length < len(accumulated_response):
                             remaining = accumulated_response[sent_length:]
-                            stream_manager.send_text(self._unescape_json_string(remaining))
+                            remaining = re.sub(r'"\s*}\s*$', '', remaining)
+                            if remaining:
+                                stream_manager.send_text(self._unescape_json_string(remaining))
 
                 else:
                     logger.info("Making non-streaming API call")
-                    message = self.client.messages.create(
+                    create_kwargs = dict(
                         max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message
                     )
+                    if output_config:
+                        create_kwargs["output_config"] = output_config
+                    message = self.client.messages.create(**create_kwargs)
 
             if hasattr(message, "usage"):
                 if message.usage.cache_creation_input_tokens:
@@ -220,9 +258,6 @@ class AnthropicClient:
                     logger.warning(f"Unhandled content type: {content_block.type}")
 
             response = "\n\n".join(response_parts)
-
-            if suggest_code is True:
-                response = '{\n  "code_edits": [' + response # Add back the prefilled opening
 
             if suggest_code is True:
                 # Parse JSON response and apply code edits
@@ -286,13 +321,21 @@ class AnthropicClient:
 
                 if suggest_code and not text_started:
                     # Code edits phase: buffer silently until text_answer starts
-                    delimiter = ',\n  "text_answer": "'
+                    delimiter = '"text_answer": "'
 
                     if delimiter in accumulated_response:
-                        # Extract code_edits JSON and apply with full error correction
-                        code_edits_raw = '[' + accumulated_response.split(delimiter)[0]
+                        # Extract code_edits from the JSON before the delimiter
+                        edits_part = accumulated_response.split(delimiter)[0]
+                        # Find the code_edits array value
                         try:
-                            code_edits = json.loads(code_edits_raw)
+                            # Build partial JSON to extract code_edits
+                            partial = edits_part.rstrip().rstrip(",")
+                            # Close the partial JSON to make it parseable
+                            if not partial.rstrip().endswith("}"):
+                                partial = partial + "}"
+                            partial_data = json.loads(partial)
+                            code_edits = partial_data.get("code_edits", [])
+
                             if original_code and code_edits:
                                 suggested_code, diff = self.apply_code_edits(
                                     content=content or "",
@@ -306,8 +349,8 @@ class AnthropicClient:
                                     stream_manager.send_changes({"code_edits": code_edits})
                             elif code_edits:
                                 stream_manager.send_changes({"code_edits": code_edits})
-                        except json.JSONDecodeError:
-                            logger.warning(f"Failed to parse code_edits: {code_edits_raw[:200]}")
+                        except (json.JSONDecodeError, ValueError):
+                            logger.warning(f"Failed to parse code_edits during streaming")
 
                         # Mark where text content starts in the accumulated buffer
                         text_offset = accumulated_response.find(delimiter) + len(delimiter)

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -189,11 +189,14 @@ class AnthropicClient:
                         refresh_rag=refresh_rag
                         )
 
-            # Structured outputs for suggest_code mode
-            output_config = (
-                {"format": {"type": "json_schema", "schema": _CODE_OUTPUT_SCHEMA}}
-                if suggest_code else None
-            )
+            # Structured outputs for suggest_code mode, effort for all modes
+            if suggest_code:
+                output_config = {
+                    "format": {"type": "json_schema", "schema": _CODE_OUTPUT_SCHEMA},
+                    "effort": "medium"
+                }
+            else:
+                output_config = {"effort": "medium"}
 
             with sentry_sdk.start_span(description="anthropic_api_call"):
                 if stream:
@@ -209,10 +212,9 @@ class AnthropicClient:
                         messages=prompt,
                         model=self.config.model,
                         system=system_message,
-                        thinking={"type": "adaptive"}
+                        thinking={"type": "adaptive"},
+                        output_config=output_config
                     )
-                    if output_config:
-                        stream_kwargs["output_config"] = output_config
 
                     with self.client.messages.stream(**stream_kwargs) as stream_obj:
                         for event in stream_obj:
@@ -240,10 +242,9 @@ class AnthropicClient:
                     logger.info("Making non-streaming API call")
                     create_kwargs = dict(
                         max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
-                        thinking={"type": "adaptive"}
+                        thinking={"type": "adaptive"},
+                        output_config=output_config
                     )
-                    if output_config:
-                        create_kwargs["output_config"] = output_config
                     message = self.client.messages.create(**create_kwargs)
 
             if hasattr(message, "usage"):
@@ -315,7 +316,9 @@ class AnthropicClient:
         then a changes event is sent, and text_answer streams to the client.
         """
         if event.type == "content_block_delta":
-            if event.delta.type == "text_delta":
+            if event.delta.type == "thinking_delta":
+                stream_manager.send_thinking(event.delta.thinking)
+            elif event.delta.type == "text_delta":
                 text_chunk = event.delta.text
                 accumulated_response += text_chunk
 
@@ -508,7 +511,10 @@ class AnthropicClient:
                 messages=prompt,
                 model=self.config.model,
                 system=system_message,
-                output_config={"format": {"type": "json_schema", "schema": correction_schema}},
+                output_config={
+                    "format": {"type": "json_schema", "schema": correction_schema},
+                    "effort": "medium"
+                },
                 thinking={"type": "adaptive"}
             )
 

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -304,7 +304,7 @@ class AnthropicClient:
                                     stream_manager.send_changes({"code": suggested_code})
                                 else:
                                     stream_manager.send_changes({"code_edits": code_edits})
-                            else:
+                            elif code_edits:
                                 stream_manager.send_changes({"code_edits": code_edits})
                         except json.JSONDecodeError:
                             logger.warning(f"Failed to parse code_edits: {code_edits_raw[:200]}")

--- a/services/job_chat/retrieve_docs.py
+++ b/services/job_chat/retrieve_docs.py
@@ -124,19 +124,34 @@ def generate_queries(content, client, user_context=""):
         user_question=content
     )
 
+    queries_schema = {
+        "type": "object",
+        "properties": {
+            "queries": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                    "additionalProperties": False
+                }
+            }
+        },
+        "required": ["queries"],
+        "additionalProperties": False
+    }
+
     text, usage = call_llm(
         model=resolve_model(config["llm_retrieval"]),
         temperature=config["temperature"],
         system_prompt=config_loader.prompts["prompts"]["search_docs_system_prompt"],
         user_prompt=formatted_user_prompt,
         client=client,
-        prefill='[\n  {"query": "'
+        output_schema=queries_schema
     )
 
     try:
-        # Prepend the prefill back to response
-        text = '[\n  {"query": "' + text
-        answer_parsed = json.loads(text)
+        answer_parsed = json.loads(text).get("queries", [])
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse LLM response as JSON: {e}. Response text: {text[:200]}")
         raise ApolloError(
@@ -181,7 +196,7 @@ def format_context(adaptor, code, history):
     
     return formatted_text
 
-def call_llm(model, temperature, system_prompt, user_prompt, client, prefill=None):
+def call_llm(model, temperature, system_prompt, user_prompt, client, output_schema=None):
     """Helper method to make LLM calls with error handling."""
     try:
         messages = [
@@ -196,20 +211,19 @@ def call_llm(model, temperature, system_prompt, user_prompt, client, prefill=Non
             }
         ]
 
-        # Add prefill if provided
-        if prefill:
-            messages.append({
-                "role": "assistant",
-                "content": prefill
-            })
-
-        message = client.messages.create(
+        kwargs = dict(
             model=model,
             max_tokens=1024,
             temperature=temperature,
             system=system_prompt,
             messages=messages
         )
+        if output_schema:
+            kwargs["output_config"] = {
+                "format": {"type": "json_schema", "schema": output_schema}
+            }
+
+        message = client.messages.create(**kwargs)
 
         # Validate response has content
         if not message.content or len(message.content) == 0:

--- a/services/models.py
+++ b/services/models.py
@@ -4,7 +4,7 @@ Update values here to change models used across all services.
 """
 
 CLAUDE_MODELS: dict[str, str] = {
-    "claude-sonnet": "claude-sonnet-4-5",
+    "claude-sonnet": "claude-sonnet-4-6",
     "claude-haiku":  "claude-haiku-4-5-20251001",
 }
 

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -160,6 +160,17 @@ prompts:
       "text": "Your reasoning (max ~4 sentences)."
     }}
 
+    ## Example Conversational Turn (no YAML change needed)
+
+    User's conversation turn:
+    "what time does the trigger run?"
+
+    The output should be:
+    {{
+      "yaml": "",
+      "text": "The cron trigger is set to run at midnight UTC every day (0 0 * * *)."
+    }}
+
     ## Do NOT fill in job code
 
     Your task is to create the workflow structure only — do NOT generate job code (i.e., the "body" key in jobs).
@@ -169,6 +180,7 @@ prompts:
 
     You must respond in JSON format with two fields: "yaml" and "text".
     "yaml" for the YAML block, and "text" for all explanation.
+    For conversational answers, the "yaml" field MUST be an empty string "".
 
   unstructured_output_format: |
     ## Read-only Mode

--- a/services/workflow_chat/gen_project_prompts.yaml
+++ b/services/workflow_chat/gen_project_prompts.yaml
@@ -167,7 +167,7 @@ prompts:
 
     The output should be:
     {{
-      "yaml": "",
+      "yaml": null,
       "text": "The cron trigger is set to run at midnight UTC every day (0 0 * * *)."
     }}
 
@@ -179,8 +179,8 @@ prompts:
     ## Output Format
 
     You must respond in JSON format with two fields: "yaml" and "text".
-    "yaml" for the YAML block, and "text" for all explanation.
-    For conversational answers, the "yaml" field MUST be an empty string "".
+    "yaml" for the YAML string, or null if no YAML changes are needed. Don't generate YAML unnecessarily.
+    "text" for all explanation.
 
   unstructured_output_format: |
     ## Read-only Mode
@@ -195,14 +195,14 @@ prompts:
 
     The output should be:
     {{
-      "yaml": "",
+      "yaml": null,
       "text": "I'd structure this as a daily cron-triggered workflow with four jobs. First, fetch visits from CommCare. Then branch based on whether visitors have IHS numbers: create encounters directly for those who do, or lookup the number first for those who don't. Here's the structure:\n\n```yaml\nname: Daily CommCare to Satusehat Encounter Sync\njobs:\n  Fetch-visits-from-CommCare:\n    name: Fetch visits from CommCare\n    adaptor: \"@openfn/language-commcare@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    name: Create FHIR Encounter for visitors with IHS number\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Lookup-IHS-number-in-Satusehat:\n    name: Lookup IHS number in Satusehat\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\n  Create-FHIR-Encounter-after-IHS-lookup:\n    name: Create FHIR Encounter after IHS lookup\n    adaptor: \"@openfn/language-satusehat@latest\"\n    body: \"// Add operations here\"\ntriggers:\n  cron:\n    type: cron\n    cron_expression: 0 0 * * *\n    enabled: false\nedges:\n  cron->Fetch-visits-from-CommCare:\n    source_trigger: cron\n    target_job: Fetch-visits-from-CommCare\n    condition_type: always\n    enabled: true\n  Fetch-visits-from-CommCare->Create-FHIR-Encounter-for-visitors-with-IHS-number:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Create-FHIR-Encounter-for-visitors-with-IHS-number\n    condition_type: on_job_success\n    enabled: true\n  Fetch-visits-from-CommCare->Lookup-IHS-number-in-Satusehat:\n    source_job: Fetch-visits-from-CommCare\n    target_job: Lookup-IHS-number-in-Satusehat\n    condition_type: on_job_success\n    enabled: true\n  Lookup-IHS-number-in-Satusehat->Create-FHIR-Encounter-after-IHS-lookup:\n    source_job: Lookup-IHS-number-in-Satusehat\n    target_job: Create-FHIR-Encounter-after-IHS-lookup\n    condition_type: on_job_success\n    enabled: true\n```"
     }}
 
     ## Output Format
 
     You must respond in JSON format with two fields: "yaml" and "text".
-    The "yaml" field should always be an empty string.
+    The "yaml" field should always be null.
     The "text" field contains your complete answer with any YAML in triple-backticked code blocks.
 
   normal_mode_intro: |
@@ -223,7 +223,7 @@ prompts:
 
   normal_mode_answering_instructions: |
     You can either
-    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as an empty string,
+    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and set the "yaml" key to null,
 
     or
 
@@ -245,13 +245,13 @@ prompts:
 
   readonly_mode_answering_instructions: |
     You can either
-    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and leave the "yaml" key as an empty string,
+    A) answer with JUST a conversational turn responding to the user (2-4 sentences) in the "text" key and set the "yaml" key to null,
 
     or
 
     B) answer with your explanation in the "text" key, including any workflow structure inline using triple-backticked YAML code blocks.
     In this case, provide a few sentences (max. as many sentences as there are jobs in the workflow) to explain your reasoning, followed by the YAML in a code block.
     If relevant, you can note aspects of the workflow that should be reviewed (e.g. to consider alternative approaches).
-    Always leave the "yaml" key as an empty string.
+    Always set the "yaml" key to null.
 
     The user's latest message and prior conversation are provided below. Generate your response accordingly.

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -161,10 +161,10 @@ class AnthropicClient:
 
             # Add prefilled opening brace for JSON response
             if read_only:
-                # In read-only mode, close yaml as empty and start text directly
-                prompt.append({"role": "assistant", "content": '{\n  "yaml": "", "text": "'})
+                # In read-only mode, close yaml as null and start text directly
+                prompt.append({"role": "assistant", "content": '{\n  "yaml": null, "text": "'})
             else:
-                prompt.append({"role": "assistant", "content": '{\n  "yaml": "'})
+                prompt.append({"role": "assistant", "content": '{\n  "yaml":'})
 
             accumulated_usage = {
                 "cache_creation_input_tokens": 0,
@@ -230,9 +230,9 @@ class AnthropicClient:
 
                 # Add back the prefilled opening
                 if read_only:
-                    response = '{\n  "yaml": "", "text": "' + response
+                    response = '{\n  "yaml": null, "text": "' + response
                 else:
-                    response = '{\n  "yaml": "' + response
+                    response = '{\n  "yaml":' + response
 
                 with sentry_sdk.start_span(description="parse_and_format_yaml"):
 
@@ -356,7 +356,7 @@ class AnthropicClient:
 
             # Extract text and yaml from the JSON
             output_text = response_data.get("text", "").strip()
-            raw_yaml = response_data.get("yaml", "")
+            raw_yaml = response_data.get("yaml") or ""
 
             if raw_yaml and raw_yaml.strip():
                 if stream_manager:
@@ -366,7 +366,7 @@ class AnthropicClient:
                 try:
                     parsed_yaml = yaml.safe_load(raw_yaml)
 
-                    if isinstance(parsed_yaml, dict) and "jobs" in parsed_yaml:
+                    if isinstance(parsed_yaml, dict):
                         with sentry_sdk.start_span(description="validate_adaptors"):
                             self.validate_adaptors(parsed_yaml)
                         with sentry_sdk.start_span(description="sanitize_job_names"):
@@ -521,21 +521,24 @@ class AnthropicClient:
 
                 if not text_started:
                     # YAML phase: buffer silently until text starts
-                    delimiter = '",\n  "text": "'
+                    delimiter = ',\n  "text": "'
 
                     if delimiter in accumulated_response:
-                        # Extract YAML content and send as changes event
-                        # yaml_raw is the string content between the prefilled opening " and delimiter "
-                        yaml_raw = accumulated_response.split(delimiter)[0]
-                        yaml_value = self._unescape_json_string(yaml_raw)
-                        if yaml_value and yaml_value != "null":
+                        # Extract YAML value (either null or a JSON string)
+                        yaml_raw = accumulated_response.split(delimiter)[0].strip()
+                        try:
+                            yaml_value = json.loads(yaml_raw)  # None for null, string for "..."
+                        except (json.JSONDecodeError, ValueError):
+                            yaml_value = None
+
+                        if yaml_value:
                             # Only send changes if the content is actually valid YAML (a dict)
                             try:
                                 parsed = yaml.safe_load(yaml_value)
                                 if isinstance(parsed, dict):
                                     stream_manager.send_changes({"yaml": yaml_value})
                             except Exception:
-                                pass  # Invalid YAML (backticks, text, etc.), skip changes event
+                                pass  # Invalid YAML, skip changes event
 
                         # Mark where text content starts
                         text_offset = accumulated_response.find(delimiter) + len(delimiter)

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -102,7 +102,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 8192
+    max_tokens: int = 16384
     api_key: Optional[str] = None
 
 
@@ -206,7 +206,8 @@ class AnthropicClient:
                             messages=prompt,
                             model=self.config.model,
                             system=system_message,
-                            output_config=output_config
+                            output_config=output_config,
+                            thinking={"type": "adaptive"}
                         ) as stream_obj:
                             for event in stream_obj:
                                 accumulated_response, text_started, sent_length = self.process_stream_event(
@@ -230,7 +231,8 @@ class AnthropicClient:
                         logger.info("Making non-streaming API call")
                         message = self.client.messages.create(
                             max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
-                            output_config=output_config
+                            output_config=output_config,
+                            thinking={"type": "adaptive"}
                         )
 
                 # Track usage from this attempt
@@ -244,8 +246,6 @@ class AnthropicClient:
                 for content_block in message.content:
                     if content_block.type == "text":
                         response_parts.append(content_block.text)
-                    else:
-                        logger.warning(f"Unhandled content type: {content_block.type}")
 
                 response = "\n\n".join(response_parts)
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -531,9 +531,7 @@ class AnthropicClient:
         is sent, and the text explanation streams to the client.
         """
         if event.type == "content_block_delta":
-            if event.delta.type == "thinking_delta":
-                stream_manager.send_thinking(event.delta.thinking)
-            elif event.delta.type == "text_delta":
+            if event.delta.type == "text_delta":
                 text_chunk = event.delta.text
                 accumulated_response += text_chunk
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -180,7 +180,8 @@ class AnthropicClient:
                 "format": {
                     "type": "json_schema",
                     "schema": _OUTPUT_SCHEMA
-                }
+                },
+                "effort": "medium"
             }
 
             accumulated_usage = {
@@ -530,7 +531,9 @@ class AnthropicClient:
         is sent, and the text explanation streams to the client.
         """
         if event.type == "content_block_delta":
-            if event.delta.type == "text_delta":
+            if event.delta.type == "thinking_delta":
+                stream_manager.send_thinking(event.delta.thinking)
+            elif event.delta.type == "text_delta":
                 text_chunk = event.delta.text
                 accumulated_response += text_chunk
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -356,28 +356,33 @@ class AnthropicClient:
 
             # Extract text and yaml from the JSON
             output_text = response_data.get("text", "").strip()
-            output_yaml = response_data.get("yaml", "")
+            raw_yaml = response_data.get("yaml", "")
 
-            if output_yaml and output_yaml.strip():
+            if raw_yaml and raw_yaml.strip():
                 if stream_manager:
                     stream_manager.send_thinking("Formatting workflow...", signature="proxy_formatting_signature")
-                # Parse YAML string into Python object
-                output_yaml = yaml.safe_load(output_yaml)
+                # Parse YAML string into Python object (separate try/except
+                # so bad yaml can't leak through to the response)
+                try:
+                    parsed_yaml = yaml.safe_load(raw_yaml)
 
-                if not isinstance(output_yaml, dict):
+                    if isinstance(parsed_yaml, dict) and "jobs" in parsed_yaml:
+                        with sentry_sdk.start_span(description="validate_adaptors"):
+                            self.validate_adaptors(parsed_yaml)
+                        with sentry_sdk.start_span(description="sanitize_job_names"):
+                            self.sanitize_job_names(parsed_yaml)
+                        with sentry_sdk.start_span(description="restore_components"):
+                            self.restore_components(parsed_yaml, preserved_values)
+                        # Convert back to YAML string with preserved order
+                        output_yaml = yaml.dump(parsed_yaml, sort_keys=False)
+                    else:
+                        output_yaml = ""
+                except Exception as e:
+                    logger.warning(f"YAML parsing failed, discarding yaml content: {e}")
                     output_yaml = ""
-                else:
-                    with sentry_sdk.start_span(description="validate_adaptors"):
-                        self.validate_adaptors(output_yaml)
-                    with sentry_sdk.start_span(description="sanitize_job_names"):
-                        self.sanitize_job_names(output_yaml)
-                    with sentry_sdk.start_span(description="restore_components"):
-                        self.restore_components(output_yaml, preserved_values)
-                    # Convert back to YAML string with preserved order
-                    output_yaml = yaml.dump(output_yaml, sort_keys=False)
             else:
                 output_yaml = ""
-                
+
         except Exception as e:
             logger.error(f"Error during JSON parsing: {str(e)}")
 
@@ -524,7 +529,13 @@ class AnthropicClient:
                         yaml_raw = accumulated_response.split(delimiter)[0]
                         yaml_value = self._unescape_json_string(yaml_raw)
                         if yaml_value and yaml_value != "null":
-                            stream_manager.send_changes({"yaml": yaml_value})
+                            # Only send changes if the content is actually valid YAML (a dict)
+                            try:
+                                parsed = yaml.safe_load(yaml_value)
+                                if isinstance(parsed, dict):
+                                    stream_manager.send_changes({"yaml": yaml_value})
+                            except Exception:
+                                pass  # Invalid YAML (backticks, text, etc.), skip changes event
 
                         # Mark where text content starts
                         text_offset = accumulated_response.find(delimiter) + len(delimiter)

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -13,6 +13,22 @@ with open(os.path.join(_dir, "gen_project_config.yaml")) as _f:
     _service_config = yaml.safe_load(_f)
 
 _MODEL = resolve_model(_service_config.get("model", "claude-sonnet"))
+
+# JSON schema for structured outputs — guarantees valid JSON from the API
+_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "yaml": {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "null"}
+            ]
+        },
+        "text": {"type": "string"}
+    },
+    "required": ["yaml", "text"],
+    "additionalProperties": False
+}
 from anthropic import (
     Anthropic,
     APIConnectionError,
@@ -159,12 +175,13 @@ class AnthropicClient:
                     read_only=read_only
                 )
 
-            # Add prefilled opening brace for JSON response
-            if read_only:
-                # In read-only mode, close yaml as null and start text directly
-                prompt.append({"role": "assistant", "content": '{\n  "yaml": null, "text": "'})
-            else:
-                prompt.append({"role": "assistant", "content": '{\n  "yaml":'})
+            # Structured outputs config — guarantees valid JSON matching schema
+            output_config = {
+                "format": {
+                    "type": "json_schema",
+                    "schema": _OUTPUT_SCHEMA
+                }
+            }
 
             accumulated_usage = {
                 "cache_creation_input_tokens": 0,
@@ -180,7 +197,7 @@ class AnthropicClient:
                         logger.info("Making streaming API call")
                         stream_manager.send_thinking("Thinking...")
 
-                        text_started = read_only  # In read-only mode, text starts immediately (no yaml phase)
+                        text_started = False
                         sent_length = 0
                         accumulated_response = ""
 
@@ -188,7 +205,8 @@ class AnthropicClient:
                             max_tokens=self.config.max_tokens,
                             messages=prompt,
                             model=self.config.model,
-                            system=system_message
+                            system=system_message,
+                            output_config=output_config
                         ) as stream_obj:
                             for event in stream_obj:
                                 accumulated_response, text_started, sent_length = self.process_stream_event(
@@ -200,16 +218,19 @@ class AnthropicClient:
                                 )
                         message = stream_obj.get_final_message()
 
-                        # Flush any remaining buffered text
+                        # Flush any remaining buffered text, stripping JSON closing chars
                         if text_started:
                             if sent_length < len(accumulated_response):
                                 remaining = accumulated_response[sent_length:]
-                                stream_manager.send_text(self._unescape_json_string(remaining))
+                                remaining = re.sub(r'"\s*}\s*$', '', remaining)
+                                if remaining:
+                                    stream_manager.send_text(self._unescape_json_string(remaining))
 
                     else:
                         logger.info("Making non-streaming API call")
                         message = self.client.messages.create(
-                            max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message
+                            max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
+                            output_config=output_config
                         )
 
                 # Track usage from this attempt
@@ -227,12 +248,6 @@ class AnthropicClient:
                         logger.warning(f"Unhandled content type: {content_block.type}")
 
                 response = "\n\n".join(response_parts)
-
-                # Add back the prefilled opening
-                if read_only:
-                    response = '{\n  "yaml": null, "text": "' + response
-                else:
-                    response = '{\n  "yaml":' + response
 
                 with sentry_sdk.start_span(description="parse_and_format_yaml"):
 
@@ -520,12 +535,16 @@ class AnthropicClient:
                 accumulated_response += text_chunk
 
                 if not text_started:
-                    # YAML phase: buffer silently until text starts
-                    delimiter = ',\n  "text": "'
+                    # YAML phase: buffer silently until text starts.
+                    # Use '"text": "' as delimiter — safe because inside
+                    # a JSON string quotes are escaped as \", so this can
+                    # only appear as the actual field separator.
+                    delimiter = '"text": "'
 
                     if delimiter in accumulated_response:
                         # Extract YAML value (either null or a JSON string)
-                        yaml_raw = accumulated_response.split(delimiter)[0].strip()
+                        yaml_part = accumulated_response.split(delimiter)[0]
+                        yaml_raw = yaml_part.strip().rstrip(",").strip()
                         try:
                             yaml_value = json.loads(yaml_raw)  # None for null, string for "..."
                         except (json.JSONDecodeError, ValueError):


### PR DESCRIPTION
## Short Description

Fix conversational answer handling bugs + upgrade to Sonnet 4.6 with structured outputs and adaptive thinking in `workflow_chat`, `job_chat`, `global_chat` to make structured outputs more consistent.

Fixes #442 #310 #449

## Implementation Details

### Problem

Conversational answers (no generated code/YAML) were broken in both workflow_chat and job_chat:

- **workflow_chat**: Since we reversed the streaming order in a previous PR, the model started to handle the empty yaml field more inconsistently: backtick fences, unescaped newlines. Bad yaml strings leaked through to the frontend, causing YAML parse errors. When the JSON was malformed enough, retries would fire and sometimes produce empty responses (`response: ""`).
- **job_chat**: A `changes` SSE event was sent even when `code_edits` was empty (`[]`), causing the "apply changes" button to appear with no code.

The root cause for workflow_chat was the old prefill-based approach (`{"yaml": "`)  the model struggled to output an empty string as its first token. A bug in `split_format_yaml` then let backticks leak through: when `yaml.safe_load` threw on bad content, the broad `except` caught it but never reset `output_yaml`, so the raw string (e.g., `` '```\n```' ``) was returned as `response_yaml`.

### What changed

**Model upgrade**: `claude-sonnet-4-6` (centrally in `models.py`).

**Structured outputs** replace prefilling across all three chat services. Instead of prefilling the assistant message and hoping the model produces valid JSON, we now pass a JSON schema via `output_config` that guarantees schema-compliant responses through constrained decoding. This eliminates all JSON parsing failures, so we no longer have retries for these structural issues.

**Adaptive thinking** (`thinking: {"type": "adaptive"}`) added to all Sonnet API calls in workflow_chat, job_chat, and global_chat's planner. The effort level is lowered to "medium" in all services except the planner to account for simple conversation turns that need answers fast. This lets the model dynamically decide when to use extended thinking, improving quality on tasks like comprehensive code renames. Just switching from 4-5 to 4-6 caused tests involving multiple changes to the code to fail far more often than before, as if the new model was not being as thorough, but adaptive thinking solved this. This also means the model streams thinking statuses in the background, but I've blocked those from being shown in the front-end for now before I move onto streaming fixes because they can be unsettling ("the user just said hello instead of asking about a workflow...I think I'll answer with a brief greeting...") and they're a bit long in the front-end space currently allocated for status updates.

**Specific fixes**:

- **workflow_chat `split_format_yaml`**: Separated YAML parsing into its own inner `try/except` so bad yaml can never leak through to the response. If `yaml.safe_load` fails, `output_yaml` is explicitly set to `""`.
- **workflow_chat streaming**: Added validation that yaml content is actually a valid YAML dict before sending a `changes` SSE event. Previously any non-empty yaml string triggered the event.
- **workflow_chat prompt**: Changed the "no yaml" convention from empty string (`""`) to `null`, added a conversational example showing `"yaml": null`
- **workflow_chat** tweak prompt to tell model not to generate YAML unnecessarily. We'll address similar behaviour in more detail in another PR but it was necessary to tweak it here to test conversational turns faster.
- **job_chat empty code_edits**: Changed `else` to `elif code_edits:` so the `changes` event only fires when there are actual edits. This avoids the "apply changes" button appearing in the front-end when there are no changes.
- **job_chat error correction**: Converted the error correction prompt from prefill to structured outputs, fixing a crash when code edits fail and need self-correction.
- **job_chat retrieve_docs**: Converted search query generation from prefill to structured outputs.
- **global_chat router**: Converted routing decision from prefill + custom brace-counting JSON parser to structured outputs.
- **Streaming flush** (both services): Strip trailing JSON closing characters (`"}`) from the text stream flush, since text is now the last field in the JSON.



## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
