### PR TITLE
Global streaming

### DIFF
--- a/.changeset/rich-toes-smile.md
+++ b/.changeset/rich-toes-smile.md
@@ -1,0 +1,6 @@
+---
+"apollo": patch
+---
+
+- Add streaming support to global_chat
+- Tweak streaming output in job_chat and workflow_chat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,9 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with
 code in this repository.
 
+**Never chain Bash commands with `&&`, `;`, or `cd ... &&`. Use separate Bash
+calls instead.**
+
 ## Commands
 
 ### Development

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -3,7 +3,9 @@ Planner Agent - Coordinates tools and subagents for complex multi-step tasks.
 """
 
 import os
+import random
 from typing import List, Dict, Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from anthropic import Anthropic
 
@@ -13,7 +15,12 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent))
 
 from util import create_logger, ApolloError, sum_usage
-from streaming_util import StreamManager
+from streaming_util import (
+    StreamManager,
+    STATUS_REVIEWING_WORKFLOW,
+    STATUS_NEW_WORKFLOW,
+    STATUS_PLANNING,
+)
 from global_chat.config_loader import ConfigLoader
 from models import resolve_model
 from global_chat.tools.tool_definitions import TOOL_DEFINITIONS
@@ -80,7 +87,11 @@ class PlannerAgent:
         logger.info("Planner.run() called")
 
         stream_manager = StreamManager(model=self.model, stream=stream)
-        stream_manager.send_thinking("Analyzing request...")
+        if self.current_yaml:
+            status = random.choice(STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
+        else:
+            status = random.choice(STATUS_NEW_WORKFLOW + STATUS_PLANNING)
+        stream_manager.send_thinking(status)
 
         self.current_yaml = workflow_yaml
         self.yaml_modified = False
@@ -146,14 +157,23 @@ class PlannerAgent:
 
                         logger.info(f"Executing {len(tool_use_blocks)} tool(s): {[b.name for b in tool_use_blocks]}")
 
+                        job_code_blocks = [b for b in tool_use_blocks if b.name == "call_job_code_agent"]
+                        other_blocks = [b for b in tool_use_blocks if b.name != "call_job_code_agent"]
+
                         tool_results = []
-                        for tool_use_block in tool_use_blocks:
-                            status = self._tool_status_message(tool_use_block)
-                            stream_manager.send_thinking(status)
+
+                        for tool_use_block in other_blocks:
+                            stream_manager.send_thinking(self._tool_status_message(tool_use_block))
                             tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
                             tool_results.append(
                                 {"type": "tool_result", "tool_use_id": tool_use_block.id, "content": tool_result}
                             )
+
+                        if job_code_blocks:
+                            job_results = self._execute_job_code_tools_parallel(
+                                job_code_blocks, stream_manager, total_usage, tool_calls_meta
+                            )
+                            tool_results.extend(job_results)
 
                         content_blocks = []
                         for block in response.content:
@@ -355,6 +375,96 @@ class PlannerAgent:
             tool_result = f"Error: Unknown tool {tool_use_block.name}"
 
         return tool_result
+
+    def _execute_job_code_tools_parallel(self, blocks, stream_manager, total_usage, tool_calls_meta):
+        """Execute multiple call_job_code_agent tools with parallel API calls.
+
+        Sends all status messages up front, runs the slow subagent calls
+        concurrently, then stitches results into the YAML sequentially.
+        """
+        # Send a combined status message for all job code steps
+        names = [self._display_name_for_job(b.input.get("job_key")) for b in blocks]
+        names = [n for n in names if n]
+        if len(names) == 1:
+            status = f"Writing code for \"{names[0]}\" step..."
+        elif len(names) == 2:
+            status = f"Writing code for \"{names[0]}\" and \"{names[1]}\" steps..."
+        elif names:
+            joined = ", ".join(f"\"{n}\"" for n in names[:-1])
+            status = f"Writing code for {joined}, and \"{names[-1]}\" steps..."
+        else:
+            status = "Writing job code..."
+        stream_manager.send_thinking(status)
+
+        # Validate and prepare — skip invalid ones before launching threads
+        to_run = []
+        skipped = {}
+        for block in blocks:
+            job_key = block.input.get("job_key")
+            if not self.current_yaml:
+                skipped[block.id] = "ERROR: No workflow exists yet. Call call_workflow_agent first to create the workflow, then call call_job_code_agent."
+                tool_calls_meta.append({"tool": "call_job_code_agent", "input": block.input, "skipped": True})
+            elif job_key:
+                _, job_data = find_job_in_yaml(self.current_yaml, job_key)
+                if not job_data:
+                    skipped[block.id] = f"ERROR: Job key '{job_key}' not found in workflow YAML. Create the workflow with this job first."
+                    tool_calls_meta.append({"tool": "call_job_code_agent", "input": block.input, "skipped": True})
+                else:
+                    to_run.append(block)
+            else:
+                to_run.append(block)
+
+        # Run subagent API calls in parallel (the slow part)
+        parallel_results = {}
+        if len(to_run) > 1:
+            with ThreadPoolExecutor(max_workers=len(to_run)) as executor:
+                futures = {
+                    executor.submit(
+                        call_job_agent, block.input, self.current_yaml, self.api_key
+                    ): block
+                    for block in to_run
+                }
+                for future in as_completed(futures):
+                    block = futures[future]
+                    parallel_results[block.id] = future.result()
+        elif to_run:
+            block = to_run[0]
+            parallel_results[block.id] = call_job_agent(block.input, self.current_yaml, self.api_key)
+
+        # Stitch results and update state sequentially
+        tool_results = []
+        for block in blocks:
+            if block.id in skipped:
+                tool_results.append(
+                    {"type": "tool_result", "tool_use_id": block.id, "content": skipped[block.id]}
+                )
+                continue
+
+            subagent_result = parallel_results[block.id]
+            job_key = block.input.get("job_key")
+
+            if "usage" in subagent_result:
+                total_usage.update(sum_usage(total_usage, subagent_result["usage"]))
+
+            suggested_code = subagent_result.get("suggested_code")
+            if job_key and suggested_code and self.current_yaml:
+                self.current_yaml = stitch_job_code(self.current_yaml, job_key, suggested_code)
+                self.yaml_modified = True
+                logger.info(f"Stitched code for job '{job_key}' into current_yaml")
+
+            self.subagent_results.append(subagent_result)
+            tool_result = format_subagent_result_for_llm(subagent_result)
+            if suggested_code:
+                tool_result += "\n\n[Job code generated and stitched into the workflow.]"
+            else:
+                tool_result += "\n\n[No job code was generated.]"
+
+            tool_calls_meta.append({"tool": "call_job_code_agent", "input": block.input})
+            tool_results.append(
+                {"type": "tool_result", "tool_use_id": block.id, "content": tool_result}
+            )
+
+        return tool_results
 
     def _tool_status_message(self, tool_use_block) -> str:
         """Generate a user-facing status message for a tool call."""

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -3,7 +3,6 @@ Planner Agent - Coordinates tools and subagents for complex multi-step tasks.
 """
 
 import os
-import random
 from typing import List, Dict, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -88,10 +87,9 @@ class PlannerAgent:
 
         stream_manager = StreamManager(model=self.model, stream=stream)
         if self.current_yaml:
-            status = random.choice(STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
+            stream_manager.send_thinking(STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
         else:
-            status = random.choice(STATUS_NEW_WORKFLOW + STATUS_PLANNING)
-        stream_manager.send_thinking(status)
+            stream_manager.send_thinking(STATUS_NEW_WORKFLOW + STATUS_PLANNING)
 
         self.current_yaml = workflow_yaml
         self.yaml_modified = False
@@ -385,13 +383,9 @@ class PlannerAgent:
         # Send a combined status message for all job code steps
         names = [self._display_name_for_job(b.input.get("job_key")) for b in blocks]
         names = [n for n in names if n]
-        if len(names) == 1:
-            status = f"Writing code for \"{names[0]}\" step..."
-        elif len(names) == 2:
-            status = f"Writing code for \"{names[0]}\" and \"{names[1]}\" steps..."
-        elif names:
-            joined = ", ".join(f"\"{n}\"" for n in names[:-1])
-            status = f"Writing code for {joined}, and \"{names[-1]}\" steps..."
+        if names:
+            joined = ", ".join(f"\"{n}\"" for n in names)
+            status = f"Writing code for {joined}..."
         else:
             status = "Writing job code..."
         stream_manager.send_thinking(status)
@@ -486,14 +480,14 @@ class PlannerAgent:
             job_key = inputs.get("job_key")
             display_name = self._display_name_for_job(job_key)
             if display_name:
-                return f"Writing code for \"{display_name}\" step..."
+                return f"Writing code for \"{display_name}\"..."
             return "Writing job code..."
 
         if name == "inspect_job_code":
             job_key = inputs.get("job_key")
             display_name = self._display_name_for_job(job_key)
             if display_name:
-                return f"Reading code for \"{display_name}\" step..."
+                return f"Reading code for \"{display_name}\"..."
             return "Reading job code..."
 
         return f"Running {name}..."

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -111,7 +111,7 @@ class PlannerAgent:
         try:
             while tool_call_count < self.max_tool_calls:
                 try:
-                    response, buffered_text = self._call_api(system_prompt, messages, stream, stream_manager)
+                    response, buffered_text = self._call_api(system_prompt, messages, stream)
 
                     for field in [
                         "input_tokens",
@@ -122,13 +122,6 @@ class PlannerAgent:
                         total_usage[field] += getattr(response.usage, field, 0)
 
                     logger.info(f"Claude API call {tool_call_count + 1}: stop_reason={response.stop_reason}")
-
-                    # Forward thinking blocks to client (non-streaming only;
-                    # when streaming, thinking is already sent in real-time)
-                    if not stream:
-                        for block in response.content:
-                            if block.type == "thinking":
-                                stream_manager.send_thinking(block.thinking)
 
                     if response.stop_reason == "end_turn":
                         # Send final YAML before text, matching workflow_chat/job_chat pattern
@@ -152,10 +145,11 @@ class PlannerAgent:
                             break
 
                         logger.info(f"Executing {len(tool_use_blocks)} tool(s): {[b.name for b in tool_use_blocks]}")
-                        stream_manager.send_thinking("Working...")
 
                         tool_results = []
                         for tool_use_block in tool_use_blocks:
+                            status = self._tool_status_message(tool_use_block)
+                            stream_manager.send_thinking(status)
                             tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
                             tool_results.append(
                                 {"type": "tool_result", "tool_use_id": tool_use_block.id, "content": tool_result}
@@ -220,12 +214,16 @@ class PlannerAgent:
             },
         )
 
-    def _call_api(self, system_prompt, messages, stream, stream_manager=None):
-        """Make Claude API call. When streaming, buffers text deltas and streams thinking in real-time."""
+    def _call_api(self, system_prompt, messages, stream):
+        """Make Claude API call. When streaming, buffers text deltas for the caller to flush.
+
+        Adaptive thinking is enabled for better reasoning but thinking content
+        is not streamed to the client — it exposes internal details like tool
+        names and agent architecture. User-facing progress comes from the
+        task-specific status messages sent before each tool execution.
+        """
         if stream:
             buffered_text = []
-            active_thinking_index = None
-            thinking_signature = None
 
             with self.client.messages.stream(
                 model=self.model,
@@ -236,26 +234,9 @@ class PlannerAgent:
                 thinking={"type": "adaptive"},
             ) as stream_obj:
                 for event in stream_obj:
-                    if event.type == "content_block_start":
-                        if event.content_block.type == "thinking":
-                            active_thinking_index = event.index
-                            thinking_signature = None
-                            if stream_manager:
-                                stream_manager.start_thinking_block()
-                    elif event.type == "content_block_delta":
-                        if event.delta.type == "thinking_delta":
-                            if stream_manager:
-                                stream_manager.send_thinking_delta(event.delta.thinking)
-                        elif event.delta.type == "signature_delta":
-                            thinking_signature = (thinking_signature or "") + event.delta.signature
-                        elif event.delta.type == "text_delta":
+                    if event.type == "content_block_delta":
+                        if event.delta.type == "text_delta":
                             buffered_text.append(event.delta.text)
-                    elif event.type == "content_block_stop":
-                        if event.index == active_thinking_index:
-                            if stream_manager:
-                                stream_manager.close_thinking_block(thinking_signature)
-                            active_thinking_index = None
-                            thinking_signature = None
                 return stream_obj.get_final_message(), buffered_text
         else:
             response = self.client.beta.messages.create(
@@ -374,6 +355,59 @@ class PlannerAgent:
             tool_result = f"Error: Unknown tool {tool_use_block.name}"
 
         return tool_result
+
+    def _tool_status_message(self, tool_use_block) -> str:
+        """Generate a user-facing status message for a tool call."""
+        name = tool_use_block.name
+        inputs = tool_use_block.input or {}
+
+        if name == "search_documentation":
+            query = inputs.get("query", "")
+            if query:
+                return f"Searching documentation for \"{query}\"..."
+            return "Searching documentation..."
+
+        if name == "call_workflow_agent":
+            if self.current_yaml:
+                return "Editing workflow..."
+            return "Building workflow outline..."
+
+        if name == "call_job_code_agent":
+            job_key = inputs.get("job_key")
+            display_name = self._display_name_for_job(job_key)
+            if display_name:
+                return f"Writing code for \"{display_name}\" step..."
+            return "Writing job code..."
+
+        if name == "inspect_job_code":
+            job_key = inputs.get("job_key")
+            display_name = self._display_name_for_job(job_key)
+            if display_name:
+                return f"Reading code for \"{display_name}\" step..."
+            return "Reading job code..."
+
+        return f"Running {name}..."
+
+    def _display_name_for_job(self, job_key: str | None) -> str | None:
+        """Look up a human-readable display name for a job key.
+
+        Checks the workflow YAML for a name field first, then falls back
+        to title-casing the key (e.g. "fetch-patients" -> "Fetch Patients").
+        """
+        if not job_key:
+            return None
+
+        if self.current_yaml:
+            _, job_data = find_job_in_yaml(self.current_yaml, job_key)
+            if job_data and job_data.get("name"):
+                return self._format_display_name(job_data["name"])
+
+        return self._format_display_name(job_key)
+
+    @staticmethod
+    def _format_display_name(name: str) -> str:
+        """Format a job key or name into readable title case."""
+        return name.replace("-", " ").replace("_", " ").title()
 
     def _extract_text(self, response):
         """Extract text from response content."""

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -1,6 +1,7 @@
 """
 Planner Agent - Coordinates tools and subagents for complex multi-step tasks.
 """
+
 import os
 from typing import List, Dict, Optional
 from dataclasses import dataclass
@@ -8,6 +9,7 @@ from anthropic import Anthropic
 
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).parent.parent))
 
 from util import create_logger, ApolloError, sum_usage
@@ -25,6 +27,7 @@ logger = create_logger(__name__)
 @dataclass
 class PlannerResult:
     """Result from planner run."""
+
     response: str
     attachments: List[Dict]
     history: List[Dict]
@@ -59,12 +62,7 @@ class PlannerAgent:
         logger.info(f"PlannerAgent initialized with model: {self.model}")
 
     def run(
-        self,
-        content: str,
-        workflow_yaml: Optional[str],
-        page: Optional[str],
-        history: List[Dict],
-        stream: bool
+        self, content: str, workflow_yaml: Optional[str], page: Optional[str], history: List[Dict], stream: bool
     ) -> PlannerResult:
         """
         Run the planner agent with tool-calling loop.
@@ -74,7 +72,7 @@ class PlannerAgent:
             workflow_yaml: Full workflow YAML string (including job bodies)
             page: Current page URL (e.g. workflows/name/step-name)
             history: Conversation history
-            stream: Streaming flag (not implemented)
+            stream: Whether to stream text via SSE events
 
         Returns:
             PlannerResult with response, attachments, history, usage, meta
@@ -85,6 +83,7 @@ class PlannerAgent:
         stream_manager.send_thinking("Analyzing request...")
 
         self.current_yaml = workflow_yaml
+        self.yaml_modified = False
 
         system_prompt = self._build_system_prompt()
 
@@ -104,114 +103,97 @@ class PlannerAgent:
             "input_tokens": 0,
             "output_tokens": 0,
             "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0
+            "cache_read_input_tokens": 0,
         }
 
         final_text = ""
 
-        while tool_call_count < self.max_tool_calls:
-            try:
-                response = self.client.beta.messages.create(
-                    model=self.model,
-                    max_tokens=self.max_tokens,
-                    system=system_prompt,
-                    messages=messages,
-                    tools=self.tools,
-                    thinking={"type": "adaptive"},
-                    output_config={"effort": "high"},
-                    betas=["context-management-2025-06-27"],
-                    context_management={
-                        "edits": [
-                            {
-                                "type": "clear_tool_uses_20250919",
-                                "trigger": {
-                                    "type": "tool_uses",
-                                    "value": 20
-                                },
-                                "keep": {
-                                    "type": "tool_uses",
-                                    "value": 10
-                                },
-                                "exclude_tools": ["search_documentation"],
-                                "clear_tool_inputs": True
-                            }
-                        ]
-                    }
-                )
+        try:
+            while tool_call_count < self.max_tool_calls:
+                try:
+                    response, buffered_text = self._call_api(system_prompt, messages, stream, stream_manager)
 
-                for field in ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"]:
-                    total_usage[field] += getattr(response.usage, field, 0)
+                    for field in [
+                        "input_tokens",
+                        "output_tokens",
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                    ]:
+                        total_usage[field] += getattr(response.usage, field, 0)
 
-                logger.info(f"Claude API call {tool_call_count + 1}: stop_reason={response.stop_reason}")
+                    logger.info(f"Claude API call {tool_call_count + 1}: stop_reason={response.stop_reason}")
 
-                # Forward any thinking blocks to the client
-                for block in response.content:
-                    if block.type == "thinking":
-                        stream_manager.send_thinking(block.thinking)
+                    # Forward thinking blocks to client (non-streaming only;
+                    # when streaming, thinking is already sent in real-time)
+                    if not stream:
+                        for block in response.content:
+                            if block.type == "thinking":
+                                stream_manager.send_thinking(block.thinking)
 
-                if response.stop_reason == "end_turn":
-                    if tool_call_count > 0:
-                        stream_manager.send_thinking("Collating components...")
-                    final_text = self._extract_text(response)
-                    messages.append({
-                        "role": "assistant",
-                        "content": final_text
-                    })
-                    logger.info(f"Tool loop completed. Total calls: {tool_call_count}")
-                    break
+                    if response.stop_reason == "end_turn":
+                        # Send final YAML before text, matching workflow_chat/job_chat pattern
+                        if self.yaml_modified and self.current_yaml:
+                            stream_manager.send_changes({"yaml": self.current_yaml})
 
-                elif response.stop_reason == "tool_use":
-                    tool_use_blocks = self._find_all_tool_uses(response.content)
+                        # Flush buffered text chunks
+                        for chunk in buffered_text:
+                            stream_manager.send_text(chunk)
 
-                    if not tool_use_blocks:
-                        logger.error("tool_use stop_reason but no tool_use block found")
+                        final_text = self._extract_text(response)
+                        messages.append({"role": "assistant", "content": final_text})
+                        logger.info(f"Tool loop completed. Total calls: {tool_call_count}")
                         break
 
-                    logger.info(f"Executing {len(tool_use_blocks)} tool(s): {[b.name for b in tool_use_blocks]}")
+                    elif response.stop_reason == "tool_use":
+                        tool_use_blocks = self._find_all_tool_uses(response.content)
 
-                    tool_results = []
-                    for tool_use_block in tool_use_blocks:
-                        tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tool_use_block.id,
-                            "content": tool_result
-                        })
+                        if not tool_use_blocks:
+                            logger.error("tool_use stop_reason but no tool_use block found")
+                            break
 
-                    content_blocks = []
-                    for block in response.content:
-                        if block.type == "thinking":
-                            content_blocks.append({
-                                "type": "thinking",
-                                "thinking": block.thinking,
-                                "signature": block.signature
-                            })
-                        elif block.type == "text":
-                            content_blocks.append({"type": "text", "text": block.text})
-                        elif block.type == "tool_use":
-                            content_blocks.append({
-                                "type": "tool_use",
-                                "id": block.id,
-                                "name": block.name,
-                                "input": block.input
-                            })
+                        logger.info(f"Executing {len(tool_use_blocks)} tool(s): {[b.name for b in tool_use_blocks]}")
+                        stream_manager.send_thinking("Working...")
 
-                    messages.append({"role": "assistant", "content": content_blocks})
-                    messages.append({"role": "user", "content": tool_results})
+                        tool_results = []
+                        for tool_use_block in tool_use_blocks:
+                            tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
+                            tool_results.append(
+                                {"type": "tool_result", "tool_use_id": tool_use_block.id, "content": tool_result}
+                            )
 
-                    tool_call_count += len(tool_use_blocks)
+                        content_blocks = []
+                        for block in response.content:
+                            if block.type == "thinking":
+                                content_blocks.append({
+                                    "type": "thinking",
+                                    "thinking": block.thinking,
+                                    "signature": block.signature,
+                                })
+                            elif block.type == "text":
+                                content_blocks.append({"type": "text", "text": block.text})
+                            elif block.type == "tool_use":
+                                content_blocks.append(
+                                    {"type": "tool_use", "id": block.id, "name": block.name, "input": block.input}
+                                )
 
-                else:
-                    logger.warning(f"Unexpected stop_reason: {response.stop_reason}")
-                    break
+                        messages.append({"role": "assistant", "content": content_blocks})
+                        messages.append({"role": "user", "content": tool_results})
 
-            except Exception as e:
-                logger.exception("Error in tool-calling loop")
-                raise ApolloError(500, f"Tool execution error: {str(e)}")
+                        tool_call_count += len(tool_use_blocks)
 
-        if response.stop_reason != "end_turn":
-            final_text = self._extract_text(response)
-            logger.warning(f"Loop exited without end_turn (reason: {response.stop_reason})")
+                    else:
+                        logger.warning(f"Unexpected stop_reason: {response.stop_reason}")
+                        break
+
+                except Exception as e:
+                    logger.exception("Error in tool-calling loop")
+                    raise ApolloError(500, f"Tool execution error: {str(e)}")
+
+            if response.stop_reason != "end_turn":
+                final_text = self._extract_text(response)
+                logger.warning(f"Loop exited without end_turn (reason: {response.stop_reason})")
+        finally:
+            stream_manager.end_stream()
 
         agents_used = ["router", "planner"]
         for result in self.subagent_results:
@@ -221,7 +203,7 @@ class PlannerAgent:
                 agents_used.append(subagent_name)
 
         attachments = []
-        if self.current_yaml:
+        if self.yaml_modified and self.current_yaml:
             attachments.append({"type": "workflow_yaml", "content": self.current_yaml})
 
         return PlannerResult(
@@ -234,9 +216,70 @@ class PlannerAgent:
                 "planner_iterations": tool_call_count,
                 "tool_calls": tool_calls_meta,
                 "subagent_calls": self.subagent_results,
-                "total_tool_calls": tool_call_count
-            }
+                "total_tool_calls": tool_call_count,
+            },
         )
+
+    def _call_api(self, system_prompt, messages, stream, stream_manager=None):
+        """Make Claude API call. When streaming, buffers text deltas and streams thinking in real-time."""
+        if stream:
+            buffered_text = []
+            active_thinking_index = None
+            thinking_signature = None
+
+            with self.client.messages.stream(
+                model=self.model,
+                max_tokens=self.max_tokens,
+                system=system_prompt,
+                messages=messages,
+                tools=self.tools,
+                thinking={"type": "adaptive"},
+            ) as stream_obj:
+                for event in stream_obj:
+                    if event.type == "content_block_start":
+                        if event.content_block.type == "thinking":
+                            active_thinking_index = event.index
+                            thinking_signature = None
+                            if stream_manager:
+                                stream_manager.start_thinking_block()
+                    elif event.type == "content_block_delta":
+                        if event.delta.type == "thinking_delta":
+                            if stream_manager:
+                                stream_manager.send_thinking_delta(event.delta.thinking)
+                        elif event.delta.type == "signature_delta":
+                            thinking_signature = (thinking_signature or "") + event.delta.signature
+                        elif event.delta.type == "text_delta":
+                            buffered_text.append(event.delta.text)
+                    elif event.type == "content_block_stop":
+                        if event.index == active_thinking_index:
+                            if stream_manager:
+                                stream_manager.close_thinking_block(thinking_signature)
+                            active_thinking_index = None
+                            thinking_signature = None
+                return stream_obj.get_final_message(), buffered_text
+        else:
+            response = self.client.beta.messages.create(
+                model=self.model,
+                max_tokens=self.max_tokens,
+                system=system_prompt,
+                messages=messages,
+                tools=self.tools,
+                thinking={"type": "adaptive"},
+                output_config={"effort": "high"},
+                betas=["context-management-2025-06-27"],
+                context_management={
+                    "edits": [
+                        {
+                            "type": "clear_tool_uses_20250919",
+                            "trigger": {"type": "tool_uses", "value": 20},
+                            "keep": {"type": "tool_uses", "value": 10},
+                            "exclude_tools": ["search_documentation"],
+                            "clear_tool_inputs": True,
+                        }
+                    ]
+                },
+            )
+            return response, []
 
     def _find_all_tool_uses(self, content):
         """Find all tool_use blocks in response content."""
@@ -247,16 +290,11 @@ class PlannerAgent:
         if tool_use_block.name == "search_documentation":
             tool_result = search_documentation_tool(tool_use_block.input)
 
-            tool_calls_meta.append({
-                "tool": "search_documentation",
-                "input": tool_use_block.input
-            })
+            tool_calls_meta.append({"tool": "search_documentation", "input": tool_use_block.input})
 
         elif tool_use_block.name == "call_workflow_agent":
             subagent_result = call_workflow_agent(
-                tool_use_block.input,
-                workflow_yaml=self.current_yaml,
-                api_key=self.api_key
+                tool_use_block.input, workflow_yaml=self.current_yaml, api_key=self.api_key
             )
 
             if "usage" in subagent_result:
@@ -265,6 +303,7 @@ class PlannerAgent:
             # Update live state eagerly
             if subagent_result.get("response_yaml"):
                 self.current_yaml = subagent_result["response_yaml"]
+                self.yaml_modified = True
 
             self.subagent_results.append(subagent_result)
 
@@ -275,10 +314,7 @@ class PlannerAgent:
                 redacted = redact_job_bodies(self.current_yaml)
                 tool_result += f"\n\nUpdated workflow structure:\n{redacted}"
 
-            tool_calls_meta.append({
-                "tool": "call_workflow_agent",
-                "input": tool_use_block.input
-            })
+            tool_calls_meta.append({"tool": "call_workflow_agent", "input": tool_use_block.input})
 
         elif tool_use_block.name == "call_job_code_agent":
             job_key = tool_use_block.input.get("job_key")
@@ -292,13 +328,13 @@ class PlannerAgent:
                 _, job_data = find_job_in_yaml(self.current_yaml, job_key)
                 if not job_data:
                     tool_result = f"ERROR: Job key '{job_key}' not found in workflow YAML. Create the workflow with this job first."
-                    tool_calls_meta.append({"tool": "call_job_code_agent", "input": tool_use_block.input, "skipped": True})
+                    tool_calls_meta.append(
+                        {"tool": "call_job_code_agent", "input": tool_use_block.input, "skipped": True}
+                    )
                     return tool_result
 
             subagent_result = call_job_agent(
-                tool_use_block.input,
-                workflow_yaml=self.current_yaml,
-                api_key=self.api_key
+                tool_use_block.input, workflow_yaml=self.current_yaml, api_key=self.api_key
             )
 
             if "usage" in subagent_result:
@@ -308,6 +344,7 @@ class PlannerAgent:
             suggested_code = subagent_result.get("suggested_code")
             if job_key and suggested_code and self.current_yaml:
                 self.current_yaml = stitch_job_code(self.current_yaml, job_key, suggested_code)
+                self.yaml_modified = True
                 logger.info(f"Stitched code for job '{job_key}' into current_yaml")
 
             self.subagent_results.append(subagent_result)
@@ -317,10 +354,7 @@ class PlannerAgent:
             else:
                 tool_result += "\n\n[No job code was generated.]"
 
-            tool_calls_meta.append({
-                "tool": "call_job_code_agent",
-                "input": tool_use_block.input
-            })
+            tool_calls_meta.append({"tool": "call_job_code_agent", "input": tool_use_block.input})
 
         elif tool_use_block.name == "inspect_job_code":
             job_key = tool_use_block.input.get("job_key")
@@ -333,10 +367,7 @@ class PlannerAgent:
                 else:
                     tool_result = f"No code found for job '{job_key}'."
 
-            tool_calls_meta.append({
-                "tool": "inspect_job_code",
-                "input": tool_use_block.input
-            })
+            tool_calls_meta.append({"tool": "inspect_job_code", "input": tool_use_block.input})
 
         else:
             logger.error(f"Unknown tool: {tool_use_block.name}")
@@ -356,10 +387,4 @@ class PlannerAgent:
         """Build system prompt for planner with cache control."""
         prompt_text = self.config_loader.get_prompt("planner_system_prompt")
 
-        return [
-            {
-                "type": "text",
-                "text": prompt_text,
-                "cache_control": {"type": "ephemeral"}
-            }
-        ]
+        return [{"type": "text", "text": prompt_text, "cache_control": {"type": "ephemeral"}}]

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -3,6 +3,7 @@ Router Agent - Lightweight routing for global agent requests.
 
 Routes requests to workflow_chat, job_chat, or planner based on user intent.
 """
+
 import os
 import json
 from typing import List, Dict, Optional
@@ -12,6 +13,7 @@ from anthropic import Anthropic
 # Import utilities from parent services directory
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).parent.parent))
 
 from util import create_logger, ApolloError, sum_usage
@@ -25,14 +27,16 @@ logger = create_logger(__name__)
 @dataclass
 class RouterDecision:
     """Decision from router about where to send the request."""
+
     destination: str  # "workflow_agent" | "job_code_agent" | "planner"
-    confidence: int   # 1-5, where 5 is highest confidence
+    confidence: int  # 1-5, where 5 is highest confidence
     job_key: Optional[str] = None  # Target job key when routing to job_code_agent
 
 
 @dataclass
 class RouterResult:
     """Result from router or passthrough."""
+
     response: str
     attachments: List[Dict]
     history: List[Dict]
@@ -73,7 +77,7 @@ class RouterAgent:
         page: Optional[str],
         history: List[Dict],
         stream: bool,
-        attachments: Optional[List[Dict]] = None
+        attachments: Optional[List[Dict]] = None,
     ) -> RouterResult:
         """
         Route request to appropriate handler and execute.
@@ -95,14 +99,16 @@ class RouterAgent:
             "input_tokens": 0,
             "output_tokens": 0,
             "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0
+            "cache_read_input_tokens": 0,
         }
 
         self._input_attachments = attachments or []
 
         try:
             decision = self._make_routing_decision(content, workflow_yaml, page, history)
-            logger.info(f"Router decision: {decision.destination} (confidence: {decision.confidence}, job_key: {decision.job_key})")
+            logger.info(
+                f"Router decision: {decision.destination} (confidence: {decision.confidence}, job_key: {decision.job_key})"
+            )
         except Exception as e:
             logger.warning(f"Routing decision failed: {e}. Defaulting to planner for safety.")
             decision = RouterDecision(destination="planner", confidence=1)
@@ -110,18 +116,16 @@ class RouterAgent:
         if decision.destination == "workflow_agent":
             result = self._route_to_workflow_chat(content, workflow_yaml, history, stream, decision.confidence)
         elif decision.destination == "job_code_agent":
-            result = self._route_to_job_chat(content, workflow_yaml, page, history, stream, decision.confidence, decision.job_key)
+            result = self._route_to_job_chat(
+                content, workflow_yaml, page, history, stream, decision.confidence, decision.job_key
+            )
         else:
             result = self._route_to_planner(content, workflow_yaml, page, history, stream, decision.confidence)
 
         return result
 
     def _make_routing_decision(
-        self,
-        content: str,
-        workflow_yaml: Optional[str],
-        page: Optional[str],
-        history: List[Dict]
+        self, content: str, workflow_yaml: Optional[str], page: Optional[str], history: List[Dict]
     ) -> RouterDecision:
         """Make routing decision using Claude Haiku."""
         routing_message = self._build_routing_message(content, workflow_yaml, page, history)
@@ -158,7 +162,7 @@ class RouterAgent:
             "input_tokens": response.usage.input_tokens,
             "output_tokens": response.usage.output_tokens,
             "cache_creation_input_tokens": getattr(response.usage, "cache_creation_input_tokens", 0),
-            "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0)
+            "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0),
         }
 
         response_text = response.content[0].text if response.content else "{}"
@@ -168,18 +172,14 @@ class RouterAgent:
             return RouterDecision(
                 destination=decision_data["destination"],
                 confidence=decision_data.get("confidence", 3),
-                job_key=decision_data.get("job_key")
+                job_key=decision_data.get("job_key"),
             )
         except (json.JSONDecodeError, KeyError) as e:
             logger.error(f"Failed to parse routing decision: {e}. Response: {response_text}")
             raise
 
     def _build_routing_message(
-        self,
-        content: str,
-        workflow_yaml: Optional[str],
-        page: Optional[str],
-        history: List[Dict]
+        self, content: str, workflow_yaml: Optional[str], page: Optional[str], history: List[Dict]
     ) -> str:
         """Build message for routing decision."""
         parts = []
@@ -216,12 +216,7 @@ class RouterAgent:
         return "\n".join(parts)
 
     def _route_to_workflow_chat(
-        self,
-        content: str,
-        workflow_yaml: Optional[str],
-        history: List[Dict],
-        stream: bool,
-        confidence: int
+        self, content: str, workflow_yaml: Optional[str], history: List[Dict], stream: bool, confidence: int
     ) -> RouterResult:
         """Route directly to workflow_chat."""
         from workflow_chat.workflow_chat import main as workflow_chat_main
@@ -236,7 +231,7 @@ class RouterAgent:
             "existing_yaml": workflow_yaml,
             "history": clean_history,
             "stream": stream,
-            "api_key": self.api_key
+            "api_key": self.api_key,
         }
 
         result = workflow_chat_main(payload)
@@ -252,10 +247,7 @@ class RouterAgent:
             attachments=attachments,
             history=result["history"].copy(),
             usage=total_usage,
-            meta={
-                "agents": ["router", "workflow_agent"],
-                "router_confidence": confidence
-            }
+            meta={"agents": ["router", "workflow_agent"], "router_confidence": confidence},
         )
 
     def _route_to_job_chat(
@@ -266,7 +258,7 @@ class RouterAgent:
         history: List[Dict],
         stream: bool,
         confidence: int,
-        router_job_key: Optional[str] = None
+        router_job_key: Optional[str] = None,
     ) -> RouterResult:
         """
         Route directly to job_chat.
@@ -307,14 +299,14 @@ class RouterAgent:
             "suggest_code": True,
             "history": clean_history,
             "stream": stream,
-            "api_key": self.api_key
+            "api_key": self.api_key,
         }
 
         result = job_chat_main(payload)
         total_usage = sum_usage(self.routing_usage, result["usage"])
 
         # Stitch suggested_code back into workflow YAML
-        updated_yaml = workflow_yaml
+        updated_yaml = None
         if result.get("suggested_code") and workflow_yaml and matched_job_key:
             updated_yaml = stitch_job_code(workflow_yaml, matched_job_key, result["suggested_code"])
         elif result.get("suggested_code") and not matched_job_key:
@@ -334,10 +326,7 @@ class RouterAgent:
             attachments=attachments,
             history=result["history"].copy(),
             usage=total_usage,
-            meta={
-                "agents": ["router", "job_code_agent"],
-                "router_confidence": confidence
-            }
+            meta={"agents": ["router", "job_code_agent"], "router_confidence": confidence},
         )
 
     def _route_to_planner(
@@ -347,7 +336,7 @@ class RouterAgent:
         page: Optional[str],
         history: List[Dict],
         stream: bool,
-        confidence: int
+        confidence: int,
     ) -> RouterResult:
         """Delegate to PlannerAgent for complex orchestration."""
         from global_chat.planner import PlannerAgent
@@ -359,11 +348,7 @@ class RouterAgent:
 
         planner = PlannerAgent(self.config_loader, self.api_key)
         planner_result = planner.run(
-            content=enriched_content,
-            workflow_yaml=workflow_yaml,
-            page=page,
-            history=clean_history,
-            stream=stream
+            content=enriched_content, workflow_yaml=workflow_yaml, page=page, history=clean_history, stream=stream
         )
 
         total_usage = sum_usage(self.routing_usage, planner_result.usage)
@@ -376,6 +361,5 @@ class RouterAgent:
             attachments=planner_result.attachments,
             history=planner_result.history,
             usage=total_usage,
-            meta=meta
+            meta=meta,
         )
-

--- a/services/global_chat/subagent_caller.py
+++ b/services/global_chat/subagent_caller.py
@@ -3,6 +3,7 @@ Subagent caller tool for the supervisor agent.
 
 Handles calling subagents and managing message/YAML passing.
 """
+
 import sys
 from pathlib import Path
 from typing import Dict, Optional
@@ -16,11 +17,7 @@ from global_chat.yaml_utils import find_job_in_yaml
 logger = create_logger(__name__)
 
 
-def call_workflow_agent(
-    tool_input: Dict,
-    workflow_yaml: Optional[str] = None,
-    api_key: Optional[str] = None
-) -> Dict:
+def call_workflow_agent(tool_input: Dict, workflow_yaml: Optional[str] = None, api_key: Optional[str] = None) -> Dict:
     """
     Call the workflow agent and return its results.
 
@@ -41,11 +38,13 @@ def call_workflow_agent(
         "content": user_message,
         "existing_yaml": workflow_yaml,
         "history": [],  # Supervisor includes context in message
-        "api_key": api_key
+        "stream": False,  # Never stream subagent calls from planner
+        "api_key": api_key,
     }
 
     try:
         from workflow_chat.workflow_chat import main as workflow_chat_main
+
         result = workflow_chat_main(workflow_payload)
 
         response_preview = result.get("response", "")[:120]
@@ -62,11 +61,7 @@ def call_workflow_agent(
         raise ApolloError(500, f"workflow_agent failed: {str(e)}")
 
 
-def call_job_agent(
-    tool_input: Dict,
-    workflow_yaml: Optional[str] = None,
-    api_key: Optional[str] = None
-) -> Dict:
+def call_job_agent(tool_input: Dict, workflow_yaml: Optional[str] = None, api_key: Optional[str] = None) -> Dict:
     """
     Call the job code agent and return its results.
 
@@ -103,11 +98,12 @@ def call_job_agent(
         "suggest_code": True,
         "stream": False,
         "history": [],  # Supervisor includes context in message
-        "api_key": api_key
+        "api_key": api_key,
     }
 
     try:
         from job_chat.job_chat import main as job_chat_main
+
         result = job_chat_main(job_payload)
 
         response_preview = result.get("response", "")[:120]
@@ -126,4 +122,4 @@ def call_job_agent(
 
 def format_subagent_result_for_llm(result: Dict) -> str:
     """Return the subagent's prose response for the planner to read."""
-    return result.get('response', 'No response')
+    return result.get("response", "No response")

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -1,6 +1,5 @@
 import os
 import json
-import random
 import re
 import yaml
 from typing import List, Optional, Dict, Any
@@ -24,6 +23,7 @@ from streaming_util import (
     StreamManager,
     STATUS_REVIEWING_CODE,
     STATUS_NEW_CODE,
+    STATUS_WORKING,
 )
 from models import resolve_model
 
@@ -169,10 +169,9 @@ class AnthropicClient:
 
             stream_manager = StreamManager(model=self.config.model, stream=stream)
             if context and context.get("expression"):
-                status = random.choice(STATUS_REVIEWING_CODE)
+                stream_manager.send_thinking(STATUS_REVIEWING_CODE)
             else:
-                status = random.choice(STATUS_NEW_CODE)
-            stream_manager.send_thinking(status)
+                stream_manager.send_thinking(STATUS_NEW_CODE)
 
             with sentry_sdk.start_span(description="build_prompt"):
                 if suggest_code is True:
@@ -227,6 +226,8 @@ class AnthropicClient:
 
                     with self.client.messages.stream(**stream_kwargs) as stream_obj:
                         for event in stream_obj:
+                            if event.type == "message_start":
+                                stream_manager.send_thinking(STATUS_WORKING)
                             accumulated_response, text_started, sent_length = self.process_stream_event(
                                 event,
                                 accumulated_response,

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -1,5 +1,6 @@
 import os
 import json
+import random
 import re
 import yaml
 from typing import List, Optional, Dict, Any
@@ -19,7 +20,11 @@ import sentry_sdk
 from util import ApolloError, create_logger, AdaptorSpecifier, add_page_prefix
 from .prompt import build_prompt, build_error_correction_prompt
 from .old_prompt import build_old_prompt
-from streaming_util import StreamManager
+from streaming_util import (
+    StreamManager,
+    STATUS_REVIEWING_CODE,
+    STATUS_NEW_CODE,
+)
 from models import resolve_model
 
 _dir = os.path.dirname(os.path.abspath(__file__))
@@ -163,7 +168,11 @@ class AnthropicClient:
             history = history.copy() if history else []
 
             stream_manager = StreamManager(model=self.config.model, stream=stream)
-            stream_manager.send_thinking("Thinking...")
+            if context and context.get("expression"):
+                status = random.choice(STATUS_REVIEWING_CODE)
+            else:
+                status = random.choice(STATUS_NEW_CODE)
+            stream_manager.send_thinking(status)
 
             with sentry_sdk.start_span(description="build_prompt"):
                 if suggest_code is True:

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -314,9 +314,6 @@ def generate_system_message(context_dict, search_results, download_adaptor_docs=
                 try:
                     adaptor = AdaptorSpecifier(context.adaptor)
 
-                    if stream_manager:
-                        stream_manager.send_thinking("Loading adaptor documentation...")
-
                     signatures = fetch_signatures(adaptor, conn, auto_load=download_adaptor_docs)
 
                     if signatures:
@@ -410,14 +407,14 @@ def build_prompt(content, history, context, rag=None, api_key=None, stream_manag
     if rag and not refresh_rag:
         retrieved_knowledge = rag
     else:
-      stream_manager.send_thinking("Searching documentation...")
       try:
           retrieved_knowledge = retrieve_knowledge(
               content=content,
               history=history,
               code=context.get("expression", ""),
               adaptor=context.get("adaptor", ""),
-              api_key=api_key
+              api_key=api_key,
+              stream_manager=stream_manager,
           )
       except Exception as e:
           logger.error(f"Error retrieving knowledge: {str(e)}")

--- a/services/job_chat/retrieve_docs.py
+++ b/services/job_chat/retrieve_docs.py
@@ -37,7 +37,7 @@ def get_client(api_key=None):
     return anthropic.Anthropic(api_key=key)
 
 
-def retrieve_knowledge(content, history, code="", adaptor="", api_key=None):
+def retrieve_knowledge(content, history, code="", adaptor="", api_key=None, stream_manager=None):
     """
     Retrieve relevant documentation sections based on user's question.
     
@@ -66,6 +66,8 @@ def retrieve_knowledge(content, history, code="", adaptor="", api_key=None):
         generate_queries_usage = {}
 
         if docs_decision.lower().startswith("true"):
+            if stream_manager:
+                stream_manager.send_thinking("Searching documentation...")
             with sentry_sdk.start_span(description="generate_search_queries"):
                 search_queries, generate_queries_usage = generate_queries(content, client, user_context)
             with sentry_sdk.start_span(description="search_documentation"):

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -138,6 +138,56 @@ class StreamManager:
 
         self._close_block(block)
 
+    def start_thinking_block(self) -> None:
+        """
+        Start a new thinking block for incremental streaming.
+        Use with send_thinking_delta() and close_thinking_block() to
+        stream thinking content as it arrives from the API.
+        """
+        if self.stream_ended:
+            raise RuntimeError("Stream already ended")
+
+        if not self.stream_started:
+            self.start_stream()
+
+        self._close_open_blocks()
+
+        index = self._next_index()
+        block = ContentBlock(index=index, block_type="thinking")
+        self.blocks.append(block)
+
+        self._emit_event('content_block_start', {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {"type": "thinking", "thinking": ""},
+        })
+
+    def send_thinking_delta(self, thinking_text: str) -> None:
+        """Send an incremental thinking delta to the current open thinking block."""
+        block = self._get_current_thinking_block()
+        if block is None:
+            return
+
+        self._emit_event('content_block_delta', {
+            "type": "content_block_delta",
+            "index": block.index,
+            "delta": {"type": "thinking_delta", "thinking": thinking_text},
+        })
+
+    def close_thinking_block(self, signature: str | None = "signature_filler") -> None:
+        """Close the current thinking block with a signature."""
+        block = self._get_current_thinking_block()
+        if block is None:
+            return
+
+        self._emit_event('content_block_delta', {
+            "type": "content_block_delta",
+            "index": block.index,
+            "delta": {"type": "signature_delta", "signature": signature or "signature_filler"},
+        })
+
+        self._close_block(block)
+
     def send_text(self, text_chunk: str) -> None:
         """
         Send a text chunk. Automatically manages text content block lifecycle.
@@ -217,6 +267,13 @@ class StreamManager:
         """Get the currently open text block, if any."""
         for block in reversed(self.blocks):
             if block.is_open and block.block_type == "text":
+                return block
+        return None
+
+    def _get_current_thinking_block(self) -> ContentBlock | None:
+        """Get the currently open thinking block, if any."""
+        for block in reversed(self.blocks):
+            if block.is_open and block.block_type == "thinking":
                 return block
         return None
 

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -12,6 +12,53 @@ from typing import Any
 
 from models import CLAUDE_SONNET
 
+# Shared status message pools for user-facing progress indicators.
+# Services compose from these to build context-specific pools.
+
+STATUS_REVIEWING_WORKFLOW = [
+    "Reviewing the workflow...",
+    "Reading your workflow...",
+    "Looking over the current setup...",
+    "Reviewing the current steps...",
+    "Analyzing the workflow...",
+    "Looking at what you have so far...",
+]
+
+STATUS_NEW_WORKFLOW = [
+    "Mapping out the steps...",
+    "Gathering requirements...",
+    "Thinking about the design...",
+]
+
+STATUS_PLANNING = [
+    "Checking what's needed...",
+    "Working out the details...",
+    "Figuring out the approach...",
+    "Planning things out...",
+]
+
+STATUS_DESIGNING_WORKFLOW = [
+    "Designing the workflow...",
+    "Planning the workflow...",
+    "Working out the structure...",
+]
+
+STATUS_REVIEWING_CODE = [
+    "Reviewing the code...",
+    "Reading the current code...",
+    "Looking over the job code...",
+    "Checking the existing code...",
+    "Reviewing what you have so far...",
+]
+
+STATUS_NEW_CODE = [
+    "Preparing to write code...",
+    "Getting ready to write code...",
+    "Setting things up...",
+    "Getting started on the code...",
+    "Preparing the job code...",
+]
+
 
 @dataclass
 class ContentBlock:

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -6,6 +6,7 @@ to simplify streaming implementations across services.
 """
 
 import json
+import random
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -49,6 +50,15 @@ STATUS_REVIEWING_CODE = [
     "Looking over the job code...",
     "Checking the existing code...",
     "Reviewing what you have so far...",
+    "Digging into the code...",
+    "Having a look at your code...",
+    "Looking at what you have...",
+    "Looking things over...",
+    "Taking a look...",
+    "Getting the context...",
+    "Having a look...",
+    "Getting up to speed...",
+    "Taking stock...",
 ]
 
 STATUS_NEW_CODE = [
@@ -57,6 +67,16 @@ STATUS_NEW_CODE = [
     "Setting things up...",
     "Getting started on the code...",
     "Preparing the job code...",
+]
+
+STATUS_WORKING = [
+    "Working on it...",
+    "Working through it...",
+    "Putting it together...",
+    "Piecing it together...",
+    "Pulling it together...",
+    "Working on a response...",
+    "Sorting it out...",
 ]
 
 
@@ -138,7 +158,7 @@ class StreamManager:
 
     def send_thinking(
         self,
-        thinking_text: str,
+        thinking_text: str | list[str],
         signature: str | None = "signature_filler",
     ) -> None:
         """
@@ -146,7 +166,9 @@ class StreamManager:
         Creates a new content block, sends the thinking, and closes it.
 
         Args:
-            thinking_text: The thinking content to send
+            thinking_text: The thinking content to send. If a list is passed,
+                one entry is picked at random — convenient for rotating
+                through status message pools.
             signature: Optional signature to include with the thinking
         """
         if self.stream_ended:
@@ -154,6 +176,9 @@ class StreamManager:
 
         if not self.stream_started:
             self.start_stream()
+
+        if isinstance(thinking_text, list):
+            thinking_text = random.choice(thinking_text)
 
         self._close_open_blocks()
 

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -1,5 +1,6 @@
 import json
 import os
+import random
 import re
 import uuid
 import unicodedata
@@ -44,7 +45,12 @@ import sentry_sdk
 from util import ApolloError, create_logger, add_page_prefix
 from .gen_project_prompt import build_prompt
 from workflow_chat.available_adaptors import get_available_adaptors
-from streaming_util import StreamManager
+from streaming_util import (
+    StreamManager,
+    STATUS_REVIEWING_WORKFLOW,
+    STATUS_NEW_WORKFLOW,
+    STATUS_DESIGNING_WORKFLOW,
+)
 
 logger = create_logger("workflow_chat")
 
@@ -196,7 +202,11 @@ class AnthropicClient:
                 with sentry_sdk.start_span(description="anthropic_api_call"):
                     if stream:
                         logger.info("Making streaming API call")
-                        stream_manager.send_thinking("Thinking...")
+                        if existing_yaml and existing_yaml.strip():
+                            status = random.choice(STATUS_REVIEWING_WORKFLOW)
+                        else:
+                            status = random.choice(STATUS_NEW_WORKFLOW + STATUS_DESIGNING_WORKFLOW)
+                        stream_manager.send_thinking(status)
 
                         text_started = False
                         sent_length = 0

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -1,6 +1,5 @@
 import json
 import os
-import random
 import re
 import uuid
 import unicodedata
@@ -203,10 +202,9 @@ class AnthropicClient:
                     if stream:
                         logger.info("Making streaming API call")
                         if existing_yaml and existing_yaml.strip():
-                            status = random.choice(STATUS_REVIEWING_WORKFLOW)
+                            stream_manager.send_thinking(STATUS_REVIEWING_WORKFLOW)
                         else:
-                            status = random.choice(STATUS_NEW_WORKFLOW + STATUS_DESIGNING_WORKFLOW)
-                        stream_manager.send_thinking(status)
+                            stream_manager.send_thinking(STATUS_NEW_WORKFLOW + STATUS_DESIGNING_WORKFLOW)
 
                         text_started = False
                         sent_length = 0


### PR DESCRIPTION
## Short Description

- Edits to streaming statuses in global_chat, workflow_chat and job_chat
- Sneaks in a parallelisation for step generation via the planner agent

Fixes #443 

Requires a small tweak in Lightning to change the first status from "Generating code" to "Thinking" at minimum. Maybe a persistent event list in the future. https://github.com/OpenFn/lightning/pull/4630

## Implementation Details

## Streaming status messages

All user-facing status messages shown during request processing. Status pools are defined once in `streaming_util.py` and composed by each service.

### Frontend (Lightning)

| When | Status |
|---|---|
| User sends message | "Thinking..." |

### Planner (via global agent)

**Initial status (random from pool):**

| Context | Pool |
|---|---|
| Has existing workflow | "Reviewing the workflow...", "Reading your workflow...", "Looking over the current setup...", "Reviewing the current steps...", "Analyzing the workflow...", "Looking at what you have so far...", "Checking what's needed...", "Working out the details...", "Figuring out the approach...", "Planning things out..." |
| No existing workflow | "Mapping out the steps...", "Gathering requirements...", "Thinking about the design...", "Checking what's needed...", "Working out the details...", "Figuring out the approach...", "Planning things out..." |

**Tool execution statuses (fixed):**

| Tool | Context | Status |
|---|---|---|
| `search_documentation` | — | "Searching documentation for \"{query}\"..." |
| `call_workflow_agent` | Has existing workflow | "Editing workflow..." |
| `call_workflow_agent` | No existing workflow | "Building workflow outline..." |
| `call_job_code_agent` | Single job | "Writing code for \"{Display Name}\" step..." |
| `call_job_code_agent` | Multiple jobs | "Writing code for \"{Name A}\" and \"{Name B}\" steps..." |
| `inspect_job_code` | — | "Reading code for \"{Display Name}\" step..." |

Job display names are resolved from the YAML `name` field first, then fall back to title-casing the key (e.g. `fetch-patients` → "Fetch Patients").

### workflow_chat (direct via router)

**Initial status (random from pool):**

| Context | Pool |
|---|---|
| Has existing workflow | "Reviewing the workflow...", "Reading your workflow...", "Looking over the current setup...", "Reviewing the current steps...", "Analyzing the workflow...", "Looking at what you have so far..." |
| No existing workflow | "Mapping out the steps...", "Gathering requirements...", "Thinking about the design...", "Designing the workflow...", "Planning the workflow...", "Working out the structure..." |

**Fixed status at end:**

| When | Status |
|---|---|
| YAML formatting phase | "Formatting workflow..." |

### job_chat (direct via router)

**Initial status (random from pool):**

| Context | Pool |
|---|---|
| Has existing code | "Reviewing the code...", "Reading the current code...", "Looking over the job code...", "Checking the existing code...", "Reviewing what you have so far..." |
| No existing code | "Preparing to write code...", "Getting ready to write code...", "Setting things up...", "Getting started on the code...", "Preparing the job code..." |

**Conditional status (only shown when docs are actually needed):**

| When | Status |
|---|---|
| RAG decides docs are needed | "Searching documentation..." |

### Example narratives

**Global agent, new workflow with multiple jobs:**
```
Thinking... → Gathering requirements... → Searching documentation for "DHIS2 adaptor"... → Building workflow outline... → Writing code for "Fetch Patients" and "Send To FHIR" steps...
```

**Global agent, editing existing workflow:**
```
Thinking... → Reviewing the workflow... → Editing workflow... → Writing code for "Fetch Patients" step...
```

**Direct workflow_chat, new workflow:**
```
Thinking... → Designing the workflow... → Formatting workflow...
```

**Direct workflow_chat, existing workflow:**
```
Thinking... → Reading your workflow... → Formatting workflow...
```

**Direct job_chat, new code, needs docs:**
```
Thinking... → Preparing to write code... → Searching documentation...
```

**Direct job_chat, editing code, simple request (no docs needed):**
```
Thinking... → Reviewing the code...
```


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
