### PR TITLE
More log stuff

### DIFF
--- a/platform/src/middleware/services.ts
+++ b/platform/src/middleware/services.ts
@@ -30,13 +30,12 @@ export default async (app: Elysia, port: number) => {
     modules.forEach((m) => {
       const { name, readme } = m;
       console.log(" - mounted /services/" + name);
-      payload.session_id = ctx.uuid;
 
       // simple post
       app.post(name, async (ctx) => {
-        console.log(ctx);
         console.log(`POST /services/${name}: ${ctx.uuid}`);
         const payload = ctx.body;
+        payload.session_id = ctx.uuid;
         const result = await callService(m, port, payload as any);
 
         if (isApolloError(result)) {
@@ -53,7 +52,7 @@ export default async (app: Elysia, port: number) => {
 
       // HTTP streaming
       app.post(`${name}/stream`, async (ctx) => {
-        console.log(`STREAM /services/${name}: ${ctx.uuid}`);
+        console.log(`STREAM START /services/${name}: ${ctx.uuid}`);
         const payload = ctx.body;
         payload.session_id = ctx.uuid;
 
@@ -106,7 +105,11 @@ export default async (app: Elysia, port: number) => {
                   error instanceof Error ? error.message : "Unknown error",
               });
             } finally {
-              console.log(`${ctx.uuid} completed in ${new Date() - ctx.start}`);
+              console.log(
+                `STREAM COMPLETE ${ctx.uuid} in ${
+                  (new Date() - ctx.start) / 1000
+                }s`
+              );
               isClosed = true;
               controller.close();
             }

--- a/platform/src/middleware/services.ts
+++ b/platform/src/middleware/services.ts
@@ -30,6 +30,7 @@ export default async (app: Elysia, port: number) => {
     modules.forEach((m) => {
       const { name, readme } = m;
       console.log(" - mounted /services/" + name);
+      payload.session_id = ctx.uuid;
 
       // simple post
       app.post(name, async (ctx) => {
@@ -54,6 +55,7 @@ export default async (app: Elysia, port: number) => {
       app.post(`${name}/stream`, async (ctx) => {
         console.log(`STREAM /services/${name}: ${ctx.uuid}`);
         const payload = ctx.body;
+        payload.session_id = ctx.uuid;
 
         const stream = new ReadableStream({
           async start(controller) {

--- a/platform/src/middleware/services.ts
+++ b/platform/src/middleware/services.ts
@@ -33,7 +33,8 @@ export default async (app: Elysia, port: number) => {
 
       // simple post
       app.post(name, async (ctx) => {
-        console.log(`Calling /services/${name}`);
+        console.log(ctx);
+        console.log(`POST /services/${name}: ${ctx.uuid}`);
         const payload = ctx.body;
         const result = await callService(m, port, payload as any);
 
@@ -51,7 +52,7 @@ export default async (app: Elysia, port: number) => {
 
       // HTTP streaming
       app.post(`${name}/stream`, async (ctx) => {
-        console.log(`HTTP stream connected to ${name}`);
+        console.log(`STREAM /services/${name}: ${ctx.uuid}`);
         const payload = ctx.body;
 
         const stream = new ReadableStream({
@@ -103,6 +104,7 @@ export default async (app: Elysia, port: number) => {
                   error instanceof Error ? error.message : "Unknown error",
               });
             } finally {
+              console.log(`${ctx.uuid} completed in ${new Date() - ctx.start}`);
               isClosed = true;
               controller.close();
             }

--- a/platform/src/server.ts
+++ b/platform/src/server.ts
@@ -5,13 +5,14 @@ import setupHealthcheck from "./middleware/healthcheck";
 import setupServices from "./middleware/services";
 import { html } from "@elysiajs/html";
 import logRequest from "./util/log-request";
+import { randomUUID } from "node:crypto";
 
 export default async (port: number | string = 3000) => {
   const app = new Elysia();
 
   app.use(html());
 
-  app.derive(() => ({ start: Date.now() }));
+  app.derive(() => ({ start: Date.now(), uuid: randomUUID() }));
   app.onAfterHandle(logRequest);
 
   await setupHealthcheck(app);

--- a/platform/src/util/log-request.ts
+++ b/platform/src/util/log-request.ts
@@ -8,9 +8,12 @@ export default ({
   start: number;
 }) => {
   const duration = Date.now() - start;
-  console.log(
-    `http: ${request.method} ${new URL(request.url).pathname} → ${
-      set.status ?? 200
-    } in ${duration}ms`
-  );
+  const path = new URL(request.url).pathname;
+  if (path !== "/") {
+    console.log(
+      `http: ${request.method} ${new URL(request.url).pathname} → ${
+        set.status ?? 200
+      } in ${duration}ms`
+    );
+  }
 };


### PR DESCRIPTION
- Don't look requests to root (which the healthcheck calls and just spams
- Log better duration metadata for streaming requests
- Assign a UUID to each request which would unlock #454

I haven't pushed the request UUID into python (#454) properly because we need to rethink the loggers. That's a step for later.

Fixes #453
Fixes #459 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
