### PR TITLE
Job_chat: remove redundant job code edits

### DIFF
--- a/.changeset/plenty-hounds-ask.md
+++ b/.changeset/plenty-hounds-ask.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+job_chat: cache code edit results to avoid duplication

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -212,6 +212,9 @@ class AnthropicClient:
                     text_started = False
                     sent_length = 0
                     accumulated_response = ""
+                    self._stream_applied = False
+                    self._stream_suggested_code = None
+                    self._stream_diff = None
 
                     original_code = context.get("expression") if context and isinstance(context, dict) else None
 
@@ -271,13 +274,19 @@ class AnthropicClient:
             response = "\n\n".join(response_parts)
 
             if suggest_code is True:
-                # Parse JSON response and apply code edits
-                job_code = None
-                if context and isinstance(context, dict):
-                    job_code = context.get("expression")
-                
-                with sentry_sdk.start_span(description="parse_and_apply_edits"):
-                    text_response, suggested_code, diff = self.parse_and_apply_edits(response=response, content=content, original_code=job_code)
+                job_code = context.get("expression") if isinstance(context, dict) else None
+
+                if getattr(self, "_stream_applied", False):
+                    # Streaming already applied edits — reuse instead of redoing the work
+                    try:
+                        text_response = json.loads(response).get("text_answer", "").strip()
+                    except (json.JSONDecodeError, ValueError):
+                        text_response = response
+                    suggested_code = self._stream_suggested_code
+                    diff = self._stream_diff
+                else:
+                    with sentry_sdk.start_span(description="parse_and_apply_edits"):
+                        text_response, suggested_code, diff = self.parse_and_apply_edits(response=response, content=content, original_code=job_code)
 
             else:
                 text_response = response
@@ -354,6 +363,9 @@ class AnthropicClient:
                                     original_code=original_code,
                                     code_edits=code_edits
                                 )
+                                self._stream_applied = True
+                                self._stream_suggested_code = suggested_code
+                                self._stream_diff = diff
                                 if suggested_code:
                                     stream_manager.send_changes({"code": suggested_code})
                                 else:


### PR DESCRIPTION
## Short Description

Removes unnecessary second `apply_code_edits` in `job_chat`.

## Implementation Details

The streaming path applies edits mid-stream to emit `suggested_code` in the `changes` event, but the post-stream path was then calling `parse_and_apply_edits` in all scenarios and redoing the same edits. Now we cache the streaming-resolved result on `self` and skip the post-stream apply when it's already been run. The non-streaming path still falls through to `parse_and_apply_edits` as before.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
