### PR TITLE
Fix bun test payload echo failure

### DIFF
--- a/platform/src/middleware/services.ts
+++ b/platform/src/middleware/services.ts
@@ -34,8 +34,7 @@ export default async (app: Elysia, port: number) => {
       // simple post
       app.post(name, async (ctx) => {
         console.log(`POST /services/${name}: ${ctx.uuid}`);
-        const payload = ctx.body;
-        payload.session_id = ctx.uuid;
+        const payload = ctx.body ?? {};
         const result = await callService(m, port, payload as any);
 
         if (isApolloError(result)) {
@@ -53,8 +52,7 @@ export default async (app: Elysia, port: number) => {
       // HTTP streaming
       app.post(`${name}/stream`, async (ctx) => {
         console.log(`STREAM START /services/${name}: ${ctx.uuid}`);
-        const payload = ctx.body;
-        payload.session_id = ctx.uuid;
+        const payload = ctx.body ?? {};
 
         const stream = new ReadableStream({
           async start(controller) {

--- a/platform/src/middleware/services.ts
+++ b/platform/src/middleware/services.ts
@@ -34,7 +34,10 @@ export default async (app: Elysia, port: number) => {
       // simple post
       app.post(name, async (ctx) => {
         console.log(`POST /services/${name}: ${ctx.uuid}`);
-        const payload = ctx.body ?? {};
+        const payload = {
+          ...(ctx.body ?? {}),
+          session_id: ctx.uuid,
+        };
         const result = await callService(m, port, payload as any);
 
         if (isApolloError(result)) {
@@ -52,7 +55,10 @@ export default async (app: Elysia, port: number) => {
       // HTTP streaming
       app.post(`${name}/stream`, async (ctx) => {
         console.log(`STREAM START /services/${name}: ${ctx.uuid}`);
-        const payload = ctx.body ?? {};
+        const payload = {
+          ...(ctx.body ?? {}),
+          session_id: ctx.uuid,
+        };
 
         const stream = new ReadableStream({
           async start(controller) {

--- a/platform/test/server.test.ts
+++ b/platform/test/server.test.ts
@@ -47,12 +47,16 @@ describe("Python Services", () => {
       expect(response.status).toBe(200);
     });
 
-    it("echoes back an object", async () => {
+    it("echoes back an object with a session id", async () => {
       const json = { x: 1 };
       const response = await app.handle(post("services/echo", json));
 
       const text = await response.json();
-      expect(text).toEqual(json);
+      expect(text).toEqual({
+        ...json,
+        session_id: expect.any(String),
+      });
+      expect(text.session_id.length).toBeGreaterThan(0);
     });
 
     // echo through web socket with result and log


### PR DESCRIPTION
Fixes #463

## Summary
- Keeps the service payload echo behavior aligned with the server contract: JSON POST bodies still receive the internal `session_id` before invoking service handlers.
- Tightens the echo regression so it explicitly expects the session id instead of stripping it out.
- Preserves empty-body safety with `ctx.body ?? {}`.

## Verification
- `bun test --timeout 20000 platform/test/server.test.ts -t 'echoes back an object with a session id'` → pass
- `bun test --timeout 20000 platform/test/server.test.ts` → 7 passed
- `git diff --check`

Notes on local setup: this runner used Bun plus a local Poetry/Python shim with the minimal dependencies needed by the existing tests. No secrets, service API keys, deploys, account/payment setup, or production data were used.
