### PR TITLE
Return error if the chat answer is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # apollo
 
+## 1.1.1
+
+### Patch Changes
+
+- Improve error reporting when the model returns an empty message
+
 ## 1.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from anthropic import Anthropic
+import sentry_sdk
 
 import sys
 from pathlib import Path
@@ -208,6 +209,8 @@ class PlannerAgent:
                         logger.warning(f"Unexpected stop_reason: {response.stop_reason}")
                         break
 
+                except ApolloError:
+                    raise
                 except Exception as e:
                     logger.exception("Error in tool-calling loop")
                     raise ApolloError(500, f"Tool execution error: {str(e)}")
@@ -217,6 +220,27 @@ class PlannerAgent:
                 logger.warning(f"Loop exited without end_turn (reason: {response.stop_reason})")
         finally:
             stream_manager.end_stream()
+
+        if not final_text:
+            stop_reason = getattr(response, "stop_reason", None)
+            if tool_call_count >= self.max_tool_calls:
+                empty_reason = "max_tool_calls_hit"
+            elif stop_reason == "max_tokens":
+                empty_reason = "max_tokens"
+            elif stop_reason == "end_turn":
+                empty_reason = "no_text_blocks"
+            else:
+                empty_reason = f"unexpected_stop_reason:{stop_reason}"
+            sentry_sdk.set_tag("stop_reason", stop_reason)
+            sentry_sdk.set_tag("empty_reason", empty_reason)
+            sentry_sdk.set_context("empty_response", {
+                "service": "global_chat.planner",
+                "tool_call_count": tool_call_count,
+                "usage": total_usage,
+            })
+            if stop_reason == "max_tokens":
+                raise ApolloError(502, f"Planner response truncated ({empty_reason})", type="OUTPUT_TRUNCATED")
+            raise ApolloError(502, f"Planner produced no text ({empty_reason})", type="EMPTY_OUTPUT")
 
         agents_used = ["router", "planner"]
         for result in self.subagent_results:

--- a/services/global_chat/tests/temp_test_empty_response_guard.py
+++ b/services/global_chat/tests/temp_test_empty_response_guard.py
@@ -1,0 +1,84 @@
+"""
+Smoke test for the planner's empty-response ApolloError guard.
+
+Verifies that global_chat's PlannerAgent raises ApolloError(502) with the
+right type when the LLM produces no usable text (rather than returning a
+PlannerResult with response: "" — which would surface as HTTP 200 from
+global_chat and leave the user-side message stuck in :processing).
+
+Run from repo root:
+    poetry run pytest services/global_chat/tests/test_empty_response_guard.py -v
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dotenv import load_dotenv
+
+sys.path.append(str(Path(__file__).parent.parent.parent))
+load_dotenv(Path(__file__).parent.parent.parent.parent / ".env")
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "fake")
+os.environ.setdefault("OPENAI_API_KEY", "fake")
+
+from util import ApolloError  # noqa: E402
+from global_chat.config_loader import ConfigLoader  # noqa: E402
+from global_chat.planner import PlannerAgent  # noqa: E402
+
+
+def make_empty_message(stop_reason: str):
+    """Mock Anthropic message with no text content blocks."""
+    msg = MagicMock()
+    msg.content = []
+    msg.stop_reason = stop_reason
+
+    usage = MagicMock()
+    usage.input_tokens = 100
+    usage.output_tokens = 50
+    usage.cache_creation_input_tokens = 0
+    usage.cache_read_input_tokens = 0
+    usage.model_dump = MagicMock(return_value={
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    })
+    msg.usage = usage
+    return msg
+
+
+def _run_planner_with_response(message):
+    config_loader = ConfigLoader()
+    planner = PlannerAgent(config_loader=config_loader, api_key="fake")
+    with patch.object(planner.client.beta.messages, "create", return_value=message):
+        planner.run(
+            content="x",
+            workflow_yaml=None,
+            page=None,
+            history=[],
+            stream=False,
+        )
+
+
+def test_max_tokens_raises_output_truncated():
+    """stop_reason=max_tokens with empty content -> 502 OUTPUT_TRUNCATED."""
+    with pytest.raises(ApolloError) as exc_info:
+        _run_planner_with_response(make_empty_message("max_tokens"))
+
+    assert exc_info.value.code == 502
+    assert exc_info.value.type == "OUTPUT_TRUNCATED"
+
+
+def test_end_turn_empty_raises_empty_output():
+    """stop_reason=end_turn with no text blocks -> 502 EMPTY_OUTPUT."""
+    with pytest.raises(ApolloError) as exc_info:
+        _run_planner_with_response(make_empty_message("end_turn"))
+
+    assert exc_info.value.code == 502
+    assert exc_info.value.type == "EMPTY_OUTPUT"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -311,6 +311,20 @@ class AnthropicClient:
                 *[usage_data for usage_key, usage_data in retrieved_knowledge.get("usage", {}).items()]
             )
 
+            if not text_response:
+                stop_reason = getattr(message, "stop_reason", None)
+                empty_reason = "max_tokens" if stop_reason == "max_tokens" else "no_text_blocks"
+                sentry_sdk.set_tag("stop_reason", stop_reason)
+                sentry_sdk.set_tag("empty_reason", empty_reason)
+                sentry_sdk.set_context("empty_response", {
+                    "service": "job_chat",
+                    "suggest_code": bool(suggest_code),
+                })
+                stream_manager.end_stream()
+                if stop_reason == "max_tokens":
+                    raise ApolloError(502, "Response truncated", type="OUTPUT_TRUNCATED")
+                raise ApolloError(502, "Model returned no usable text", type="EMPTY_OUTPUT")
+
             stream_manager.end_stream()
 
             return ChatResponse(
@@ -660,6 +674,8 @@ def main(data_dict: dict) -> dict:
 
             return response_dict
 
+    except ApolloError:
+        raise
     except ValueError as e:
         raise ApolloError(400, str(e), type="BAD_REQUEST")
 

--- a/services/job_chat/tests/temp_test_empty_response_guard.py
+++ b/services/job_chat/tests/temp_test_empty_response_guard.py
@@ -1,0 +1,100 @@
+"""
+Smoke test for the empty-response ApolloError guard.
+
+Verifies that job_chat raises ApolloError(502) with the right type when
+the LLM produces no usable text, instead of returning HTTP 200 with
+response: "" — which would make Lightning's ChatMessage insert fail and
+leave the user-side message stuck in :processing.
+
+Run from repo root:
+    poetry run pytest services/job_chat/tests/test_empty_response_guard.py -v
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dotenv import load_dotenv
+
+sys.path.append(str(Path(__file__).parent.parent.parent))
+load_dotenv(Path(__file__).parent.parent.parent.parent / ".env")
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "fake")
+os.environ.setdefault("OPENAI_API_KEY", "fake")
+
+from util import ApolloError  # noqa: E402
+from job_chat.job_chat import main as job_main  # noqa: E402
+
+
+def make_empty_message(stop_reason: str):
+    """Mock Anthropic message with no text content blocks."""
+    msg = MagicMock()
+    msg.content = []
+    msg.stop_reason = stop_reason
+
+    usage = MagicMock()
+    usage.input_tokens = 100
+    usage.output_tokens = 50
+    usage.cache_creation_input_tokens = 0
+    usage.cache_read_input_tokens = 0
+    usage.model_dump = MagicMock(return_value={
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    })
+    msg.usage = usage
+    return msg
+
+
+def _payload():
+    return {
+        "content": "help with code",
+        "history": [],
+        "context": {"expression": "fn(s => s)"},
+        "api_key": "fake",
+        "stream": False,
+        "suggest_code": False,
+        "download_adaptor_docs": False,
+    }
+
+
+def _stub_prompt(*args, **kwargs):
+    return ("sys", [{"role": "user", "content": "x"}], {"usage": {}})
+
+
+def test_max_tokens_raises_output_truncated():
+    """stop_reason=max_tokens with empty content -> 502 OUTPUT_TRUNCATED."""
+    with patch("job_chat.job_chat.Anthropic") as mock_anth, \
+         patch("job_chat.job_chat.build_old_prompt", side_effect=_stub_prompt), \
+         patch("job_chat.job_chat.build_prompt", side_effect=_stub_prompt):
+        mock_client = MagicMock()
+        mock_anth.return_value = mock_client
+        mock_client.messages.create.return_value = make_empty_message("max_tokens")
+
+        with pytest.raises(ApolloError) as exc_info:
+            job_main(_payload())
+
+    assert exc_info.value.code == 502
+    assert exc_info.value.type == "OUTPUT_TRUNCATED"
+
+
+def test_end_turn_empty_raises_empty_output():
+    """stop_reason=end_turn with no text blocks -> 502 EMPTY_OUTPUT."""
+    with patch("job_chat.job_chat.Anthropic") as mock_anth, \
+         patch("job_chat.job_chat.build_old_prompt", side_effect=_stub_prompt), \
+         patch("job_chat.job_chat.build_prompt", side_effect=_stub_prompt):
+        mock_client = MagicMock()
+        mock_anth.return_value = mock_client
+        mock_client.messages.create.return_value = make_empty_message("end_turn")
+
+        with pytest.raises(ApolloError) as exc_info:
+            job_main(_payload())
+
+    assert exc_info.value.code == 502
+    assert exc_info.value.type == "EMPTY_OUTPUT"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/services/workflow_chat/tests/temp_test_empty_response_guard.py
+++ b/services/workflow_chat/tests/temp_test_empty_response_guard.py
@@ -1,0 +1,89 @@
+"""
+Smoke test for the empty-response ApolloError guard.
+
+Verifies that workflow_chat raises ApolloError(502) with the right type
+when the LLM produces no usable text, instead of returning HTTP 200 with
+response: "" — which would make Lightning's ChatMessage insert fail and
+leave the user-side message stuck in :processing.
+
+Run from repo root:
+    poetry run pytest services/workflow_chat/tests/test_empty_response_guard.py -v
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dotenv import load_dotenv
+
+sys.path.append(str(Path(__file__).parent.parent.parent))
+load_dotenv(Path(__file__).parent.parent.parent.parent / ".env")
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "fake")
+
+from util import ApolloError  # noqa: E402
+from workflow_chat.workflow_chat import main as workflow_main  # noqa: E402
+
+
+def make_empty_message(stop_reason: str):
+    """Mock Anthropic message with no text content blocks."""
+    msg = MagicMock()
+    msg.content = []
+    msg.stop_reason = stop_reason
+
+    usage = MagicMock()
+    usage.input_tokens = 100
+    usage.output_tokens = 50
+    usage.cache_creation_input_tokens = 0
+    usage.cache_read_input_tokens = 0
+    usage.model_dump = MagicMock(return_value={
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    })
+    msg.usage = usage
+    return msg
+
+
+def _payload():
+    return {
+        "content": "build a workflow",
+        "history": [],
+        "context": {"page_name": "test"},
+        "api_key": "fake",
+        "stream": False,
+    }
+
+
+def test_max_tokens_raises_output_truncated():
+    """stop_reason=max_tokens with empty content -> 502 OUTPUT_TRUNCATED."""
+    with patch("workflow_chat.workflow_chat.Anthropic") as mock_anth:
+        mock_client = MagicMock()
+        mock_anth.return_value = mock_client
+        mock_client.messages.create.return_value = make_empty_message("max_tokens")
+
+        with pytest.raises(ApolloError) as exc_info:
+            workflow_main(_payload())
+
+    assert exc_info.value.code == 502
+    assert exc_info.value.type == "OUTPUT_TRUNCATED"
+
+
+def test_end_turn_empty_raises_empty_output():
+    """stop_reason=end_turn with no text blocks -> 502 EMPTY_OUTPUT."""
+    with patch("workflow_chat.workflow_chat.Anthropic") as mock_anth:
+        mock_client = MagicMock()
+        mock_anth.return_value = mock_client
+        mock_client.messages.create.return_value = make_empty_message("end_turn")
+
+        with pytest.raises(ApolloError) as exc_info:
+            workflow_main(_payload())
+
+    assert exc_info.value.code == 502
+    assert exc_info.value.type == "EMPTY_OUTPUT"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -271,6 +271,21 @@ class AnthropicClient:
 
                 # If YAML parsing succeeded or we're on the last attempt, return the result
                 if response_yaml is not None or attempt == max_retries:
+                    if not response_text:
+                        stop_reason = getattr(message, "stop_reason", None)
+                        empty_reason = "max_tokens" if stop_reason == "max_tokens" else "no_text_blocks"
+                        sentry_sdk.set_tag("stop_reason", stop_reason)
+                        sentry_sdk.set_tag("empty_reason", empty_reason)
+                        sentry_sdk.set_context("empty_response", {
+                            "service": "workflow_chat",
+                            "attempts": attempt + 1,
+                            "usage": accumulated_usage,
+                        })
+                        stream_manager.end_stream()
+                        if stop_reason == "max_tokens":
+                            raise ApolloError(502, "Response truncated", type="OUTPUT_TRUNCATED")
+                        raise ApolloError(502, "Model returned no usable text", type="EMPTY_OUTPUT")
+
                     # Add prefix to content when building history
                     prefixed_content = add_page_prefix(content, current_page)
 
@@ -650,6 +665,8 @@ def main(data_dict: dict) -> dict:
 
             return response_dict
 
+    except ApolloError:
+        raise
     except ValueError as e:
         raise ApolloError(400, str(e), type="BAD_REQUEST")
 


### PR DESCRIPTION
## Short Description

`workflow_chat`, `global_chat`, and `job_chat` could return HTTP 200 with response: `""` when the LLM produced no usable text. Lightning treated the 200 as success leaving the user-side message stuck in `:processing`. Each service now raises ApolloError when there's no usable text, so Lightning's handle_error_response routes it into the error tuple.

Fixes #484 

## Implementation Details

### ApolloError usage
Each service raises `ApolloError(502, ...)` when text output is empty after the existing retry/loop logic. Type is `OUTPUT_TRUNCATED` for `stop_reason=max_tokens`, `EMPTY_OUTPUT` otherwise. Code and types are new values within the existing `ApolloError` shape.

### Sentry tracking
We attach Sentry reporting before each raise. `entry.py`'s existing capture_exception records one event per failed request.

### Tests
Added temporary tests in separate test files that won't run automatically. This is to avoid conflicts from our testing architecture which is currently in progress. These tests will need to be rewritten to fit into the new tests.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
