### PR TITLE
Update assistants  to Fable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # apollo
 
+## 1.3.1
+
+### Patch Changes
+
+- Use Anthropic Fable in chat assistants
+
 ## 1.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/services/doc_agent_chat/agent.py
+++ b/services/doc_agent_chat/agent.py
@@ -1,5 +1,6 @@
 import os
 from typing import List, Dict, Any, Optional
+import httpx
 from anthropic import Anthropic
 from util import create_logger
 from doc_agent_chat.doc_search import DocSearch
@@ -22,9 +23,7 @@ class Agent:
         if not self.api_key:
             raise ValueError("API key must be provided")
 
-        # Explicit timeout: with max_tokens > ~21k the SDK refuses
-        # non-streaming requests unless a timeout is set.
-        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
+        self.client = Anthropic(api_key=self.api_key)
         self.model = resolve_model(config.get("model", "claude-fable"))
         self.max_tokens = config.get("max_tokens", 49152)
         self.max_tool_calls = config.get("max_tool_calls", 10)
@@ -65,7 +64,11 @@ class Agent:
                 max_tokens=self.max_tokens,
                 system=system_prompt,
                 messages=messages,
-                tools=TOOL_DEFINITIONS
+                tools=TOOL_DEFINITIONS,
+                # Per-request timeout (same values as the SDK default):
+                # required for non-streaming calls with max_tokens > ~21k,
+                # which the SDK otherwise rejects.
+                timeout=httpx.Timeout(600.0, connect=5.0),
             )
 
             if hasattr(response, "usage"):

--- a/services/doc_agent_chat/agent.py
+++ b/services/doc_agent_chat/agent.py
@@ -22,9 +22,11 @@ class Agent:
         if not self.api_key:
             raise ValueError("API key must be provided")
 
-        self.client = Anthropic(api_key=self.api_key)
-        self.model = resolve_model(config.get("model", "claude-sonnet"))
-        self.max_tokens = config.get("max_tokens", 16384)
+        # Explicit timeout: with max_tokens > ~21k the SDK refuses
+        # non-streaming requests unless a timeout is set.
+        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
+        self.model = resolve_model(config.get("model", "claude-fable"))
+        self.max_tokens = config.get("max_tokens", 49152)
         self.max_tool_calls = config.get("max_tool_calls", 10)
         self.search_top_k = config.get("search_top_k", 5)
         self.search_threshold = config.get("search_threshold", 0.7)

--- a/services/doc_agent_chat/config.yaml
+++ b/services/doc_agent_chat/config.yaml
@@ -1,7 +1,6 @@
 config_version: 1.0
-model: claude-sonnet
-max_tokens: 16384
-temperature: 0
+model: claude-fable
+max_tokens: 49152
 max_tool_calls: 10
 search_top_k: 5
 search_threshold: 0.7

--- a/services/global_chat/config.yaml
+++ b/services/global_chat/config.yaml
@@ -8,7 +8,6 @@ router:
 
 # Planner configuration (complex orchestration)
 planner:
-  model: "claude-sonnet"
-  max_tokens: 8192
-  temperature: 1.0
+  model: "claude-fable"
+  max_tokens: 24576
   max_tool_calls: 10

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -6,6 +6,7 @@ import os
 from typing import List, Dict, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+import httpx
 from anthropic import Anthropic
 import sentry_sdk
 
@@ -55,9 +56,7 @@ class PlannerAgent:
         if not self.api_key:
             raise ApolloError(500, "ANTHROPIC_API_KEY not found")
 
-        # Explicit timeout: with max_tokens > ~21k the SDK refuses
-        # non-streaming requests unless a timeout is set.
-        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
+        self.client = Anthropic(api_key=self.api_key)
         self.tools = TOOL_DEFINITIONS
 
         planner_config = config_loader.config.get("planner", {})
@@ -302,6 +301,10 @@ class PlannerAgent:
                 tools=self.tools,
                 thinking={"type": "adaptive"},
                 output_config={"effort": "medium"},
+                # Per-request timeout (same values as the SDK default):
+                # required for non-streaming calls with max_tokens > ~21k,
+                # which the SDK otherwise rejects.
+                timeout=httpx.Timeout(600.0, connect=5.0),
                 betas=["context-management-2025-06-27"],
                 context_management={
                     "edits": [

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -55,13 +55,14 @@ class PlannerAgent:
         if not self.api_key:
             raise ApolloError(500, "ANTHROPIC_API_KEY not found")
 
-        self.client = Anthropic(api_key=self.api_key)
+        # Explicit timeout: with max_tokens > ~21k the SDK refuses
+        # non-streaming requests unless a timeout is set.
+        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
         self.tools = TOOL_DEFINITIONS
 
         planner_config = config_loader.config.get("planner", {})
-        self.model = resolve_model(planner_config.get("model", "claude-sonnet"))
-        self.max_tokens = planner_config.get("max_tokens", 8192)
-        self.temperature = planner_config.get("temperature", 1.0)
+        self.model = resolve_model(planner_config.get("model", "claude-fable"))
+        self.max_tokens = planner_config.get("max_tokens", 24576)
         self.max_tool_calls = planner_config.get("max_tool_calls", 20)
 
         self.current_yaml: Optional[str] = None
@@ -285,6 +286,7 @@ class PlannerAgent:
                 messages=messages,
                 tools=self.tools,
                 thinking={"type": "adaptive"},
+                output_config={"effort": "medium"},
             ) as stream_obj:
                 for event in stream_obj:
                     if event.type == "content_block_delta":
@@ -299,7 +301,7 @@ class PlannerAgent:
                 messages=messages,
                 tools=self.tools,
                 thinking={"type": "adaptive"},
-                output_config={"effort": "high"},
+                output_config={"effort": "medium"},
                 betas=["context-management-2025-06-27"],
                 context_management={
                     "edits": [

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -34,7 +34,7 @@ _dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(_dir, "rag.yaml")) as _f:
     _service_config = yaml.safe_load(_f)
 
-_MODEL = resolve_model(_service_config.get("model", "claude-sonnet"))
+_MODEL = resolve_model(_service_config.get("model", "claude-fable"))
 
 logger = create_logger("job_chat")
 
@@ -138,7 +138,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 16384
+    max_tokens: int = 49152
     api_key: Optional[str] = None
 
 
@@ -157,7 +157,9 @@ class AnthropicClient:
         self.api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("API key must be provided")
-        self.client = Anthropic(api_key=self.api_key)
+        # Explicit timeout: with max_tokens > ~21k the SDK refuses
+        # non-streaming requests unless a timeout is set.
+        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
 
     @staticmethod
     def _unescape_json_string(text):

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -4,6 +4,7 @@ import re
 import yaml
 from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
+import httpx
 from anthropic import (
     Anthropic,
     APIConnectionError,
@@ -157,9 +158,7 @@ class AnthropicClient:
         self.api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("API key must be provided")
-        # Explicit timeout: with max_tokens > ~21k the SDK refuses
-        # non-streaming requests unless a timeout is set.
-        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
+        self.client = Anthropic(api_key=self.api_key)
 
     @staticmethod
     def _unescape_json_string(text):
@@ -290,6 +289,10 @@ class AnthropicClient:
                         max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
                         thinking={"type": "adaptive"},
                         output_config=output_config,
+                        # Per-request timeout (same values as the SDK default):
+                        # required for non-streaming calls with max_tokens > ~21k,
+                        # which the SDK otherwise rejects.
+                        timeout=httpx.Timeout(600.0, connect=5.0),
                         **tool_kwargs
                     )
                     message = self.client.messages.create(**create_kwargs)

--- a/services/job_chat/rag.yaml
+++ b/services/job_chat/rag.yaml
@@ -1,5 +1,5 @@
 config_version: 1.0
-model: "claude-sonnet"
+model: "claude-fable"
 llm_search_decision: "claude-sonnet"
 llm_retrieval: "claude-sonnet"
 threshold: 0.8

--- a/services/models.py
+++ b/services/models.py
@@ -5,11 +5,16 @@ Update values here to change models used across all services.
 
 CLAUDE_MODELS: dict[str, str] = {
     "claude-opus":   "claude-opus-4-8",
+    # Fable rejects temperature/top_p/top_k and any explicit `thinking`
+    # config other than {"type": "adaptive"}; tokenizer yields ~30% more
+    # tokens than Sonnet/Opus for the same content.
+    "claude-fable":  "claude-fable-5",
     "claude-sonnet": "claude-sonnet-4-6",
     "claude-haiku":  "claude-haiku-4-5-20251001",
 }
 
 CLAUDE_OPUS:   str = CLAUDE_MODELS["claude-opus"]
+CLAUDE_FABLE:  str = CLAUDE_MODELS["claude-fable"]
 CLAUDE_SONNET: str = CLAUDE_MODELS["claude-sonnet"]
 CLAUDE_HAIKU:  str = CLAUDE_MODELS["claude-haiku"]
 

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -11,7 +11,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
-from models import CLAUDE_SONNET
+from models import CLAUDE_FABLE
 
 # Shared status message pools for user-facing progress indicators.
 # Services compose from these to build context-specific pools.
@@ -105,7 +105,7 @@ class StreamManager:
         manager.end_stream()
     """
 
-    def __init__(self, model: str = CLAUDE_SONNET, stream: bool = True):
+    def __init__(self, model: str = CLAUDE_FABLE, stream: bool = True):
         """
         Initialize the stream manager.
 

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -11,7 +11,6 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
-from models import CLAUDE_FABLE
 
 # Shared status message pools for user-facing progress indicators.
 # Services compose from these to build context-specific pools.
@@ -97,7 +96,7 @@ class StreamManager:
     block lifecycle and index tracking.
 
     Example usage:
-        manager = StreamManager()
+        manager = StreamManager(model=resolve_model("claude-fable"))
         manager.start_stream()
         manager.send_thinking("Researching...")
         manager.send_text("Here's what I found...")
@@ -105,12 +104,13 @@ class StreamManager:
         manager.end_stream()
     """
 
-    def __init__(self, model: str = CLAUDE_FABLE, stream: bool = True):
+    def __init__(self, model: str, stream: bool = True):
         """
         Initialize the stream manager.
 
         Args:
-            model: Model name to include in message_start event
+            model: Model name to include in message_start event. Required so
+                the stream metadata always reflects the model actually used.
         """
         self.stream = stream
         self.model = model

--- a/services/testing/judge.py
+++ b/services/testing/judge.py
@@ -34,11 +34,11 @@ from typing import Optional
 
 from anthropic import Anthropic
 
-from models import CLAUDE_SONNET
+from models import CLAUDE_FABLE
 from testing.judges import load_judge
 
 
-DEFAULT_MODEL = CLAUDE_SONNET
+DEFAULT_MODEL = CLAUDE_FABLE
 DEFAULT_JUDGE = "general"
 
 
@@ -277,7 +277,7 @@ def evaluate(
             guessing.
         judge: Name of the judge (file at services/testing/judges/<name>.md).
             Defaults to "general".
-        model: Model to use. Defaults to CLAUDE_SONNET from services/models.py.
+        model: Model to use. Defaults to CLAUDE_FABLE from services/models.py.
         client: Optional Anthropic client. Constructed from env if not given.
 
     Returns:
@@ -298,14 +298,16 @@ def evaluate(
 
     response = client.messages.create(
         model=model,
-        max_tokens=4096,
+        max_tokens=8192,
         system=system_prompt,
         messages=[
             {"role": "user", "content": user_prompt},
         ],
     )
 
-    raw_text = response.content[0].text
+    # First text block, not content[0]: Fable always thinks, so the
+    # response may lead with a thinking block.
+    raw_text = next((b.text for b in response.content if b.type == "text"), "")
     usage = {
         "input_tokens": response.usage.input_tokens,
         "output_tokens": response.usage.output_tokens,

--- a/services/workflow_chat/gen_project_config.yaml
+++ b/services/workflow_chat/gen_project_config.yaml
@@ -1,5 +1,4 @@
 config_version: 1.0
-model: "claude-sonnet"
+model: "claude-fable"
 threshold: 0.7
 top_k: 5
-temperature: 0

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -29,6 +29,7 @@ _OUTPUT_SCHEMA = {
     "required": ["yaml", "text"],
     "additionalProperties": False
 }
+import httpx
 from anthropic import (
     Anthropic,
     APIConnectionError,
@@ -131,9 +132,7 @@ class AnthropicClient:
         self.api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("API key must be provided")
-        # Explicit timeout: with max_tokens > ~21k the SDK refuses
-        # non-streaming requests unless a timeout is set.
-        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
+        self.client = Anthropic(api_key=self.api_key)
         # Holds the finalized YAML sent in the streaming `changes` event. The
         # final response reuses this exact string rather than finalizing again,
         # so restore_components runs once and new-component UUIDs stay identical
@@ -258,7 +257,11 @@ class AnthropicClient:
                         message = self.client.messages.create(
                             max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
                             output_config=output_config,
-                            thinking={"type": "adaptive"}
+                            thinking={"type": "adaptive"},
+                            # Per-request timeout (same values as the SDK default):
+                            # required for non-streaming calls with max_tokens > ~21k,
+                            # which the SDK otherwise rejects.
+                            timeout=httpx.Timeout(600.0, connect=5.0),
                         )
 
                 # Track usage from this attempt

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -12,7 +12,7 @@ _dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(_dir, "gen_project_config.yaml")) as _f:
     _service_config = yaml.safe_load(_f)
 
-_MODEL = resolve_model(_service_config.get("model", "claude-sonnet"))
+_MODEL = resolve_model(_service_config.get("model", "claude-fable"))
 
 # JSON schema for structured outputs — guarantees valid JSON from the API
 _OUTPUT_SCHEMA = {
@@ -113,7 +113,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 16384
+    max_tokens: int = 49152
     api_key: Optional[str] = None
 
 
@@ -131,7 +131,9 @@ class AnthropicClient:
         self.api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("API key must be provided")
-        self.client = Anthropic(api_key=self.api_key)
+        # Explicit timeout: with max_tokens > ~21k the SDK refuses
+        # non-streaming requests unless a timeout is set.
+        self.client = Anthropic(api_key=self.api_key, timeout=600.0)
         # Holds the finalized YAML sent in the streaming `changes` event. The
         # final response reuses this exact string rather than finalizing again,
         # so restore_components runs once and new-component UUIDs stay identical


### PR DESCRIPTION
## Short Description

Moves the main chat services (job_chat, workflow_chat,  global_chat planner + doc_agent_chat prototype) from Sonnet to Claude Fable 5. Keeps RAG helpers, vocab_mapper, and the test judge on Sonnet.

This will increase our model costs, possibly by 5x. It is difficult to evaluate without running a lot of tests because thinking behaviour (i.e. output token volume) will vary between models and calls.

I haven't tested the effects of this update extensively. I skimmed over acceptance tests for the three chat services and tested locally with Lightning to see everything still works and doesn't seem slower. We'll be ready to rollback if there's complaints.

Fixes #524 

## Implementation details

  - models.py: add "claude-fable" alias and CLAUDE_FABLE constant for claude-fable-5
  - Point service configs at claude-fable: rag.yaml (model), gen_project_config.yaml, doc_agent_chat/config.yaml, global_chat/config.yaml (planner). Code fallback defaults updated to match.
  - Keep on Sonnet: job_chat RAG calls (llm_search_decision, llm_retrieval), vocab_mapper.
  - Triple max_tokens on Fable routes to absorb the new tokenizer (~30% more tokens): 16384 → 49152 (job_chat, workflow_chat, doc_agent_chat), 8192 → 24576 (planner).
  - Pass an explicit per-request timeout=httpx.Timeout(600.0, connect=5.0) on the four non-streaming messages.create calls (job_chat, workflow_chat, doc_agent_chat, planner). Required: the SDK rejects non-streaming requests with max_tokens > ~21k unless a timeout is given. Values match the SDK default, so no behaviour change.
  - Planner effort switched from high to medium.
  - Remove dead temperature config: unread keys in doc_agent_chat, workflow_chat, and planner configs, plus the planner's unused self.temperature. Live temperature=0 settings (RAG, vocab_mapper, router) are unchanged and stay on Sonnet/Haiku, which accept it.
  

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
