### PR TITLE
Revert assistants to Fable; release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # apollo
 
-## 1.3.1
+## 1.3.2
 
 ### Patch Changes
 
-- Use Anthropic Fable in chat assistants
+- Revert "Update assistants to Fable" (1.3.1). Restores the 1.3.0 model
+  configuration (Opus/Sonnet/Haiku) across the chat assistants. 1.3.2 is
+  functionally identical to 1.3.0 and is released as the new `latest`.
 
 ## 1.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/services/doc_agent_chat/agent.py
+++ b/services/doc_agent_chat/agent.py
@@ -1,6 +1,5 @@
 import os
 from typing import List, Dict, Any, Optional
-import httpx
 from anthropic import Anthropic
 from util import create_logger
 from doc_agent_chat.doc_search import DocSearch
@@ -24,8 +23,8 @@ class Agent:
             raise ValueError("API key must be provided")
 
         self.client = Anthropic(api_key=self.api_key)
-        self.model = resolve_model(config.get("model", "claude-fable"))
-        self.max_tokens = config.get("max_tokens", 49152)
+        self.model = resolve_model(config.get("model", "claude-sonnet"))
+        self.max_tokens = config.get("max_tokens", 16384)
         self.max_tool_calls = config.get("max_tool_calls", 10)
         self.search_top_k = config.get("search_top_k", 5)
         self.search_threshold = config.get("search_threshold", 0.7)
@@ -64,11 +63,7 @@ class Agent:
                 max_tokens=self.max_tokens,
                 system=system_prompt,
                 messages=messages,
-                tools=TOOL_DEFINITIONS,
-                # Per-request timeout (same values as the SDK default):
-                # required for non-streaming calls with max_tokens > ~21k,
-                # which the SDK otherwise rejects.
-                timeout=httpx.Timeout(600.0, connect=5.0),
+                tools=TOOL_DEFINITIONS
             )
 
             if hasattr(response, "usage"):

--- a/services/doc_agent_chat/config.yaml
+++ b/services/doc_agent_chat/config.yaml
@@ -1,6 +1,7 @@
 config_version: 1.0
-model: claude-fable
-max_tokens: 49152
+model: claude-sonnet
+max_tokens: 16384
+temperature: 0
 max_tool_calls: 10
 search_top_k: 5
 search_threshold: 0.7

--- a/services/global_chat/config.yaml
+++ b/services/global_chat/config.yaml
@@ -8,6 +8,7 @@ router:
 
 # Planner configuration (complex orchestration)
 planner:
-  model: "claude-fable"
-  max_tokens: 24576
+  model: "claude-sonnet"
+  max_tokens: 8192
+  temperature: 1.0
   max_tool_calls: 10

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -6,7 +6,6 @@ import os
 from typing import List, Dict, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-import httpx
 from anthropic import Anthropic
 import sentry_sdk
 
@@ -60,8 +59,9 @@ class PlannerAgent:
         self.tools = TOOL_DEFINITIONS
 
         planner_config = config_loader.config.get("planner", {})
-        self.model = resolve_model(planner_config.get("model", "claude-fable"))
-        self.max_tokens = planner_config.get("max_tokens", 24576)
+        self.model = resolve_model(planner_config.get("model", "claude-sonnet"))
+        self.max_tokens = planner_config.get("max_tokens", 8192)
+        self.temperature = planner_config.get("temperature", 1.0)
         self.max_tool_calls = planner_config.get("max_tool_calls", 20)
 
         self.current_yaml: Optional[str] = None
@@ -285,7 +285,6 @@ class PlannerAgent:
                 messages=messages,
                 tools=self.tools,
                 thinking={"type": "adaptive"},
-                output_config={"effort": "medium"},
             ) as stream_obj:
                 for event in stream_obj:
                     if event.type == "content_block_delta":
@@ -300,11 +299,7 @@ class PlannerAgent:
                 messages=messages,
                 tools=self.tools,
                 thinking={"type": "adaptive"},
-                output_config={"effort": "medium"},
-                # Per-request timeout (same values as the SDK default):
-                # required for non-streaming calls with max_tokens > ~21k,
-                # which the SDK otherwise rejects.
-                timeout=httpx.Timeout(600.0, connect=5.0),
+                output_config={"effort": "high"},
                 betas=["context-management-2025-06-27"],
                 context_management={
                     "edits": [

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -4,7 +4,6 @@ import re
 import yaml
 from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
-import httpx
 from anthropic import (
     Anthropic,
     APIConnectionError,
@@ -35,7 +34,7 @@ _dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(_dir, "rag.yaml")) as _f:
     _service_config = yaml.safe_load(_f)
 
-_MODEL = resolve_model(_service_config.get("model", "claude-fable"))
+_MODEL = resolve_model(_service_config.get("model", "claude-sonnet"))
 
 logger = create_logger("job_chat")
 
@@ -139,7 +138,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 49152
+    max_tokens: int = 16384
     api_key: Optional[str] = None
 
 
@@ -289,10 +288,6 @@ class AnthropicClient:
                         max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
                         thinking={"type": "adaptive"},
                         output_config=output_config,
-                        # Per-request timeout (same values as the SDK default):
-                        # required for non-streaming calls with max_tokens > ~21k,
-                        # which the SDK otherwise rejects.
-                        timeout=httpx.Timeout(600.0, connect=5.0),
                         **tool_kwargs
                     )
                     message = self.client.messages.create(**create_kwargs)

--- a/services/job_chat/rag.yaml
+++ b/services/job_chat/rag.yaml
@@ -1,5 +1,5 @@
 config_version: 1.0
-model: "claude-fable"
+model: "claude-sonnet"
 llm_search_decision: "claude-sonnet"
 llm_retrieval: "claude-sonnet"
 threshold: 0.8

--- a/services/models.py
+++ b/services/models.py
@@ -5,16 +5,11 @@ Update values here to change models used across all services.
 
 CLAUDE_MODELS: dict[str, str] = {
     "claude-opus":   "claude-opus-4-8",
-    # Fable rejects temperature/top_p/top_k and any explicit `thinking`
-    # config other than {"type": "adaptive"}; tokenizer yields ~30% more
-    # tokens than Sonnet/Opus for the same content.
-    "claude-fable":  "claude-fable-5",
     "claude-sonnet": "claude-sonnet-4-6",
     "claude-haiku":  "claude-haiku-4-5-20251001",
 }
 
 CLAUDE_OPUS:   str = CLAUDE_MODELS["claude-opus"]
-CLAUDE_FABLE:  str = CLAUDE_MODELS["claude-fable"]
 CLAUDE_SONNET: str = CLAUDE_MODELS["claude-sonnet"]
 CLAUDE_HAIKU:  str = CLAUDE_MODELS["claude-haiku"]
 

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -11,6 +11,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+from models import CLAUDE_SONNET
 
 # Shared status message pools for user-facing progress indicators.
 # Services compose from these to build context-specific pools.
@@ -96,7 +97,7 @@ class StreamManager:
     block lifecycle and index tracking.
 
     Example usage:
-        manager = StreamManager(model=resolve_model("claude-fable"))
+        manager = StreamManager()
         manager.start_stream()
         manager.send_thinking("Researching...")
         manager.send_text("Here's what I found...")
@@ -104,13 +105,12 @@ class StreamManager:
         manager.end_stream()
     """
 
-    def __init__(self, model: str, stream: bool = True):
+    def __init__(self, model: str = CLAUDE_SONNET, stream: bool = True):
         """
         Initialize the stream manager.
 
         Args:
-            model: Model name to include in message_start event. Required so
-                the stream metadata always reflects the model actually used.
+            model: Model name to include in message_start event
         """
         self.stream = stream
         self.model = model

--- a/services/testing/judge.py
+++ b/services/testing/judge.py
@@ -34,11 +34,11 @@ from typing import Optional
 
 from anthropic import Anthropic
 
-from models import CLAUDE_FABLE
+from models import CLAUDE_SONNET
 from testing.judges import load_judge
 
 
-DEFAULT_MODEL = CLAUDE_FABLE
+DEFAULT_MODEL = CLAUDE_SONNET
 DEFAULT_JUDGE = "general"
 
 
@@ -277,7 +277,7 @@ def evaluate(
             guessing.
         judge: Name of the judge (file at services/testing/judges/<name>.md).
             Defaults to "general".
-        model: Model to use. Defaults to CLAUDE_FABLE from services/models.py.
+        model: Model to use. Defaults to CLAUDE_SONNET from services/models.py.
         client: Optional Anthropic client. Constructed from env if not given.
 
     Returns:
@@ -298,16 +298,14 @@ def evaluate(
 
     response = client.messages.create(
         model=model,
-        max_tokens=8192,
+        max_tokens=4096,
         system=system_prompt,
         messages=[
             {"role": "user", "content": user_prompt},
         ],
     )
 
-    # First text block, not content[0]: Fable always thinks, so the
-    # response may lead with a thinking block.
-    raw_text = next((b.text for b in response.content if b.type == "text"), "")
+    raw_text = response.content[0].text
     usage = {
         "input_tokens": response.usage.input_tokens,
         "output_tokens": response.usage.output_tokens,

--- a/services/workflow_chat/gen_project_config.yaml
+++ b/services/workflow_chat/gen_project_config.yaml
@@ -1,4 +1,5 @@
 config_version: 1.0
-model: "claude-fable"
+model: "claude-sonnet"
 threshold: 0.7
 top_k: 5
+temperature: 0

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -12,7 +12,7 @@ _dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(_dir, "gen_project_config.yaml")) as _f:
     _service_config = yaml.safe_load(_f)
 
-_MODEL = resolve_model(_service_config.get("model", "claude-fable"))
+_MODEL = resolve_model(_service_config.get("model", "claude-sonnet"))
 
 # JSON schema for structured outputs — guarantees valid JSON from the API
 _OUTPUT_SCHEMA = {
@@ -29,7 +29,6 @@ _OUTPUT_SCHEMA = {
     "required": ["yaml", "text"],
     "additionalProperties": False
 }
-import httpx
 from anthropic import (
     Anthropic,
     APIConnectionError,
@@ -114,7 +113,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 49152
+    max_tokens: int = 16384
     api_key: Optional[str] = None
 
 
@@ -257,11 +256,7 @@ class AnthropicClient:
                         message = self.client.messages.create(
                             max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
                             output_config=output_config,
-                            thinking={"type": "adaptive"},
-                            # Per-request timeout (same values as the SDK default):
-                            # required for non-streaming calls with max_tokens > ~21k,
-                            # which the SDK otherwise rejects.
-                            timeout=httpx.Timeout(600.0, connect=5.0),
+                            thinking={"type": "adaptive"}
                         )
 
                 # Track usage from this attempt


### PR DESCRIPTION
Reverts #525 (the 1.3.1 "Update assistants to Fable" change), restoring the 1.3.0 model configuration (Opus/Sonnet/Haiku) across the chat assistants. **1.3.2 is functionally identical to 1.3.0** — the service code is byte-identical to the `@openfn/apollo@1.3.0` tag; only `package.json` (version bump) and `CHANGELOG.md` differ.

### Why a 1.3.2 revert instead of deleting 1.3.1
Rollback was requested because Fable is not available out the US (or even at times in the US). Rather than deleting the 1.3.1 DockerHub image and GitHub tag (irreversible, breaks anyone pinned to it, loses the audit trail), this ships a new patch that supersedes it:

- 1.3.1 tags/images stay intact and become a cleanly skippable version
- Merging bumps the version, so `auto-tag.yaml` pushes `@openfn/apollo@1.3.2` and `dockerize.yaml` publishes `openfn/apollo:v1.3.2` **and re-points `openfn/apollo:latest`** to the working build