### PR TITLE
fix: job_chat drops generated code when the job is empty

### DIFF
--- a/.changeset/ninety-meteors-shake.md
+++ b/.changeset/ninety-meteors-shake.md
@@ -1,0 +1,6 @@
+---
+"apollo": patch
+---
+
+Fix an issue in job_chat where no code is returned if an an empty job expression
+is sent

--- a/.changeset/ninety-meteors-shake.md
+++ b/.changeset/ninety-meteors-shake.md
@@ -1,6 +1,0 @@
----
-"apollo": patch
----
-
-Fix an issue in job_chat where no code is returned if an an empty job expression
-is sent

--- a/.changeset/ripe-poets-enjoy.md
+++ b/.changeset/ripe-poets-enjoy.md
@@ -1,5 +1,0 @@
----
-"apollo": patch
----
-
-update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # apollo
 
+## 1.3.3
+
+### Patch Changes
+
+- 824b99f: Fix an issue in job_chat where no code is returned if an an empty job
+  expression is sent
+- e5daf45: update dependencies
+
 ## 1.3.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "module": "platform/index.ts",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "start": "NODE_ENV=production bun platform/src/index.ts",

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -315,12 +315,13 @@ class AnthropicClient:
 
             if suggest_code is True and tool_code_edits:
                 job_code = context.get("expression") if isinstance(context, dict) else None
-                if job_code:
-                    with sentry_sdk.start_span(description="apply_code_edits"):
-                        suggested_code, diff = self.apply_code_edits(
-                            content=content, text_answer=text_response,
-                            original_code=job_code, code_edits=tool_code_edits,
-                        )
+                # Apply edits even for an empty job: it's just the blank-file
+                # case. See https://github.com/OpenFn/apollo/issues/539.
+                with sentry_sdk.start_span(description="apply_code_edits"):
+                    suggested_code, diff = self.apply_code_edits(
+                        content=content, text_answer=text_response,
+                        original_code=job_code or "", code_edits=tool_code_edits,
+                    )
                 # If the model called the tool but emitted no prose, give the user
                 # a short confirmation so the response isn't empty.
                 if not text_response and suggested_code:
@@ -421,10 +422,10 @@ class AnthropicClient:
             text_answer = response_data.get("text_answer", "").strip()
             code_edits = response_data.get("code_edits", [])
             
-            if not code_edits or not original_code:
+            if not code_edits:
                 return text_answer, None, None
-            
-            suggested_code, diff = self.apply_code_edits(content=content, text_answer=text_answer, original_code=original_code, code_edits=code_edits)
+
+            suggested_code, diff = self.apply_code_edits(content=content, text_answer=text_answer, original_code=original_code or "", code_edits=code_edits)
             return text_answer, suggested_code, diff
             
         except json.JSONDecodeError as e:
@@ -472,7 +473,16 @@ class AnthropicClient:
         })
 
         action = edit.get("action")
-        
+
+        # Empty job: there is nothing to edit against, so the new code IS the
+        # result regardless of action (replace vs rewrite). Handling this here
+        # keeps correctness independent of which action the model picks.
+        # See https://github.com/OpenFn/apollo/issues/539.
+        if not code.strip():
+            new_code = edit.get("new_code")
+            if new_code:
+                return new_code, True, None
+
         if action == "replace":
             old_code = edit.get("old_code")
             new_code = edit.get("new_code")

--- a/services/job_chat/prompt.py
+++ b/services/job_chat/prompt.py
@@ -184,6 +184,10 @@ Each item in `code_edits`:
 - {"action": "replace", "old_code": "<exact code to find>", "new_code": "<replacement>"}
 - {"action": "rewrite", "new_code": "<complete new code>"}
 
+If the current job is EMPTY (no code at all), you MUST use the "rewrite" action
+with the complete code. There is nothing to "replace" in an empty job, so a
+"replace" edit will not apply.
+
 <code editing rules>
 - old_code must match the user's code EXACTLY, including all whitespace and indentation.
 - Edits apply sequentially — later edits work on the already-modified code.

--- a/services/job_chat/tests/unit/test_empty_job_edits.py
+++ b/services/job_chat/tests/unit/test_empty_job_edits.py
@@ -1,0 +1,87 @@
+"""Unit tests for writing code into an empty/new job (issue #539).
+
+Before the fix, the assistant silently dropped generated code when the job body
+was empty: `generate()` only applied edits `if job_code:`, and
+`parse_and_apply_edits()` short-circuited on `not original_code`. The user saw a
+preamble ("I'll add a fn()...") with no code.
+
+These exercise the pure edit-application methods. We build the instance with
+`__new__` to skip `__init__` (which constructs an Anthropic client, blocked in
+unit tests); the `rewrite` path never touches the LLM client.
+"""
+
+import json
+
+from job_chat.job_chat import AnthropicClient
+
+
+def _client():
+    return AnthropicClient.__new__(AnthropicClient)
+
+
+def test_rewrite_into_empty_job_returns_full_code():
+    suggested, diff = _client().apply_code_edits(
+        content="write a simple http post",
+        text_answer="I'll add it",
+        original_code="",
+        code_edits=[{"action": "rewrite", "new_code": "post('https://x.test', state.data);"}],
+    )
+
+    assert suggested == "post('https://x.test', state.data);"
+    assert diff["patches_applied"] == 1
+
+
+def test_replace_action_into_empty_job_writes_code():
+    # The model may send a "replace" against an empty job. With nothing to find,
+    # the new code is still the result, deterministically and without an LLM
+    # error-correction round-trip.
+    suggested, diff = _client().apply_code_edits(
+        content="write a simple http post",
+        text_answer="I'll add it",
+        original_code="",
+        code_edits=[
+            {"action": "replace", "old_code": "// anything", "new_code": "post('https://x.test');"}
+        ],
+    )
+
+    assert suggested == "post('https://x.test');"
+    assert diff["patches_applied"] == 1
+
+
+def test_whitespace_only_job_treated_as_empty():
+    suggested, diff = _client().apply_code_edits(
+        content="write a simple http post",
+        text_answer="I'll add it",
+        original_code="   \n\n  ",
+        code_edits=[{"action": "rewrite", "new_code": "post('https://x.test');"}],
+    )
+
+    assert suggested == "post('https://x.test');"
+    assert diff["patches_applied"] == 1
+
+
+def test_parse_and_apply_no_longer_drops_code_on_empty_original():
+    response = json.dumps(
+        {
+            "text_answer": "I'll write it",
+            "code_edits": [{"action": "rewrite", "new_code": "get('https://x.test');"}],
+        }
+    )
+
+    text, suggested, diff = _client().parse_and_apply_edits(
+        response, content="x", original_code=""
+    )
+
+    assert suggested == "get('https://x.test');"
+    assert diff["patches_applied"] == 1
+
+
+def test_no_code_edits_still_returns_none():
+    response = json.dumps({"text_answer": "just explaining", "code_edits": []})
+
+    text, suggested, diff = _client().parse_and_apply_edits(
+        response, content="x", original_code=""
+    )
+
+    assert suggested is None
+    assert diff is None


### PR DESCRIPTION
## Short Description

`job_chat` generated code but returned nothing when the job body was empty. This makes it return the code.

Fixes #539

## Implementation Details

`job_chat` writes job code by editing what's already there. When the job is empty there's nothing to edit, so it dropped the code it generated and only returned the chat reply. Downstream that shows up as the assistant promising code and never delivering it.

Changes in `services/job_chat`:

- `generate()`: apply the edit even when the job is empty (a blank job is just a blank file to write into).
- `apply_single_edit()`: if the job is empty, use the new code directly no matter which edit action the model picked. Keeps it correct even when the model doesn't choose "rewrite", and skips a wasted retry.
- prompt: nudge the model to use "rewrite" on an empty job.

Added unit tests for the empty job cases (rewrite, replace, whitespace-only, and no edit).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
