### PR TITLE
Upgrade to Claude Opus

### DIFF
--- a/.changeset/twelve-lemons-tan.md
+++ b/.changeset/twelve-lemons-tan.md
@@ -1,0 +1,5 @@
+---
+"apollo": minor
+---
+
+upgrade to opus in planner and job chat

--- a/services/global_chat/config.yaml
+++ b/services/global_chat/config.yaml
@@ -9,6 +9,5 @@ router:
 # Planner configuration (complex orchestration)
 planner:
   model: "claude-opus"
-  max_tokens: 8192
-  temperature: 1.0
+  max_tokens: 24576
   max_tool_calls: 10

--- a/services/global_chat/config.yaml
+++ b/services/global_chat/config.yaml
@@ -8,7 +8,7 @@ router:
 
 # Planner configuration (complex orchestration)
 planner:
-  model: "claude-sonnet"
+  model: "claude-opus"
   max_tokens: 8192
   temperature: 1.0
   max_tool_calls: 10

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -6,6 +6,7 @@ import os
 from typing import List, Dict, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+import httpx
 from anthropic import Anthropic
 import sentry_sdk
 
@@ -59,9 +60,8 @@ class PlannerAgent:
         self.tools = TOOL_DEFINITIONS
 
         planner_config = config_loader.config.get("planner", {})
-        self.model = resolve_model(planner_config.get("model", "claude-sonnet"))
-        self.max_tokens = planner_config.get("max_tokens", 8192)
-        self.temperature = planner_config.get("temperature", 1.0)
+        self.model = resolve_model(planner_config.get("model", "claude-opus"))
+        self.max_tokens = planner_config.get("max_tokens", 24576)
         self.max_tool_calls = planner_config.get("max_tool_calls", 20)
 
         self.current_yaml: Optional[str] = None
@@ -285,6 +285,7 @@ class PlannerAgent:
                 messages=messages,
                 tools=self.tools,
                 thinking={"type": "adaptive"},
+                output_config={"effort": "medium"},
             ) as stream_obj:
                 for event in stream_obj:
                     if event.type == "content_block_delta":
@@ -299,7 +300,11 @@ class PlannerAgent:
                 messages=messages,
                 tools=self.tools,
                 thinking={"type": "adaptive"},
-                output_config={"effort": "high"},
+                output_config={"effort": "medium"},
+                # Per-request timeout (same values as the SDK default):
+                # required for non-streaming calls with max_tokens > ~21k,
+                # which the SDK otherwise rejects.
+                timeout=httpx.Timeout(600.0, connect=5.0),
                 betas=["context-management-2025-06-27"],
                 context_management={
                     "edits": [

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -139,7 +139,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 32768
+    max_tokens: int = 24576
     api_key: Optional[str] = None
 
 

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -4,6 +4,7 @@ import re
 import yaml
 from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
+import httpx
 from anthropic import (
     Anthropic,
     APIConnectionError,
@@ -138,7 +139,7 @@ class Payload:
 @dataclass
 class ChatConfig:
     model: str = _MODEL
-    max_tokens: int = 16384
+    max_tokens: int = 32768
     api_key: Optional[str] = None
 
 
@@ -288,6 +289,10 @@ class AnthropicClient:
                         max_tokens=self.config.max_tokens, messages=prompt, model=self.config.model, system=system_message,
                         thinking={"type": "adaptive"},
                         output_config=output_config,
+                        # Per-request timeout (same values as the SDK default):
+                        # required for non-streaming calls with max_tokens > ~21k,
+                        # which the SDK otherwise rejects.
+                        timeout=httpx.Timeout(600.0, connect=5.0),
                         **tool_kwargs
                     )
                     message = self.client.messages.create(**create_kwargs)

--- a/services/job_chat/rag.yaml
+++ b/services/job_chat/rag.yaml
@@ -1,5 +1,5 @@
 config_version: 1.0
-model: "claude-sonnet"
+model: "claude-opus"
 llm_search_decision: "claude-sonnet"
 llm_retrieval: "claude-sonnet"
 threshold: 0.8


### PR DESCRIPTION
## Short Description

Upgrade to Claude Opus in global_chat and job_chat.

Fixes #533 

## Implementation Details
This is a minimal model upgrade (as opposed to the earlier PR with new model selection options https://github.com/OpenFn/apollo/pull/528)

  - Planner agent (global_chat) and job code agent now use Claude Opus instead of Sonnet, with a higher token limit (8k → 24k) and the dead temperature setting removed.
  - Reasoning effort on the planner lowered from high to medium (for faster responses).
  - Added explicit per-request timeouts on both services, which are required when max_tokens goes above ~21k for non-streaming calls.

From running the acceptance tests once, I can see that Opus can be more concise; general judge results on job_chat test pass rate increases from 6/8 -> 8/9 while code quality pass rate stays at 3/9.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
