### PR TITLE
Global chat: Add answer streaming to planner

### DIFF
--- a/.changeset/short-months-look.md
+++ b/.changeset/short-months-look.md
@@ -1,0 +1,6 @@
+---
+"apollo": minor
+---
+
+global chat: add answer streaming to the planner, breaking up responses into
+chunks which can be rendered earlier

--- a/services/global_chat/PAYLOAD_SPEC.md
+++ b/services/global_chat/PAYLOAD_SPEC.md
@@ -84,7 +84,12 @@ This document defines the input and output payload structure for the Global Agen
 
 ```json
 {
-  "response": "string",                  // Main text response
+  "response": "string",                  // Main text response (final answer)
+
+  "response_segments": [                 // Full transcript of the turn, in stream order
+    { "type": "status", "content": "Reviewing the workflow..." },
+    { "type": "text",   "content": "..." }
+  ],
 
   "attachments": [                       // Artifacts produced this turn
     {
@@ -96,8 +101,8 @@ This document defines the input and output payload structure for the Global Agen
   "history": [                           // Conversation history including this turn
     {
       "role": "user|assistant",
-      "content": "string | array"        // string for direct routes; array of content
-    }                                    // blocks (text, tool_use, tool_result) for planner path
+      "content": "string"
+    }
   ],
 
   "usage": {                             // Token usage (aggregated across all agents)
@@ -125,11 +130,17 @@ This document defines the input and output payload structure for the Global Agen
 
 ### Field Descriptions
 
-- **`response`** (string): The main text response from the agent.
+- **`response`** (string): The main text response from the agent — the final answer. On the planner path this is the text of the planner's last round only (narration from earlier rounds is not included).
+
+- **`response_segments`** (array): The full transcript of the turn in the order it was streamed, as `{"type", "content"}` objects. Two segment types:
+  - `text` — a text block from the model. On the planner path there is one per round of the tool-calling loop; the last one equals `response`.
+  - `status` — a user-facing status message ("Reviewing the workflow...", "Writing code for \"Fetch Patients\"...") exactly as it was shown in the stream (status pools are picked randomly, so this records the actual pick).
+
+  This lets the frontend persist and re-render the woven stream view after a page reload without reconstructing it from stream events. On direct routes (workflow_agent, job_code_agent) it is a single `text` segment wrapping `response` — statuses emitted internally by those subagents are not captured.
 
 - **`attachments`** (array): Artifacts produced during this turn. Each entry has a `type` and `content` field. An empty list `[]` means no artifacts were produced (e.g. a purely informational response). The only supported type is `workflow_yaml`: the full workflow YAML with any job code changes stitched in. Job code edits are never returned separately — the YAML is the single source of truth, which allows multi-step changes in one response.
 
-- **`history`** (array): Updated conversation history including the latest exchange. On direct routes (workflow_agent, job_code_agent), each entry has `content` as a string. On the planner path, entries may have `content` as an array of content blocks (`text`, `tool_use`, `tool_result`) — this is the raw Anthropic messages format from the tool-calling loop.
+- **`history`** (array): Updated conversation history including the latest exchange. Each entry has `content` as a string on every route. On the planner path the assistant entry contains only the final answer text — the pre-tool narration segments in `response` are not persisted to history.
 
 - **`usage`** (object): Token usage aggregated across all agents invoked (router + planner + sub-agents).
 

--- a/services/global_chat/PAYLOAD_SPEC.md
+++ b/services/global_chat/PAYLOAD_SPEC.md
@@ -86,9 +86,10 @@ This document defines the input and output payload structure for the Global Agen
 {
   "response": "string",                  // Main text response (final answer)
 
-  "response_segments": [                 // Full transcript of the turn, in stream order
-    { "type": "status", "content": "Reviewing the workflow..." },
-    { "type": "text",   "content": "..." }
+  "response_segments": [                 // Durable transcript of the turn, in stream order
+    { "type": "text",   "content": "I'll add the step..." },
+    { "type": "status", "content": "Edited workflow structure" },
+    { "type": "text",   "content": "Done! I added..." }
   ],
 
   "attachments": [                       // Artifacts produced this turn
@@ -132,11 +133,20 @@ This document defines the input and output payload structure for the Global Agen
 
 - **`response`** (string): The main text response from the agent — the final answer. On the planner path this is the text of the planner's last round only (narration from earlier rounds is not included).
 
-- **`response_segments`** (array): The full transcript of the turn in the order it was streamed, as `{"type", "content"}` objects. Two segment types:
+- **`response_segments`** (array): The durable transcript of the turn in the order it was streamed, as `{"type", "content"}` objects. Two segment types:
   - `text` — a text block from the model. On the planner path there is one per round of the tool-calling loop; the last one equals `response`.
-  - `status` — a user-facing status message ("Reviewing the workflow...", "Writing code for \"Fetch Patients\"...") exactly as it was shown in the stream (status pools are picked randomly, so this records the actual pick).
+  - `status` — a completed-action status line ("Edited workflow structure", "Wrote code for \"Fetch Patients\""). Only these settled lines are recorded; the transient "...ing" spinners shown while an action runs are never persisted.
 
-  This lets the frontend persist and re-render the woven stream view after a page reload without reconstructing it from stream events. On direct routes (workflow_agent, job_code_agent) it is a single `text` segment wrapping `response` — statuses emitted internally by those subagents are not captured.
+  This lets the frontend persist and re-render the woven view after a page reload without reconstructing it from stream events. On direct routes (workflow_agent, job_code_agent) it is a single `text` segment wrapping `response` — statuses emitted internally by those subagents are not captured.
+
+#### Streaming status events (planner path)
+
+Apollo classifies status messages by event type so the client never has to infer their meaning from the text:
+
+- **`thinking` events** (standard Anthropic thinking blocks) — transient progress spinners ("Reviewing the workflow...", "Writing code for \"X\"..."). Render live; each new status replaces the previous one; drop when the next text block starts. Never persist these.
+- **`status` events** (custom event, like `changes`) — completed-action lines. Payload is `{"type": "status", "content": "Edited workflow structure"}`, identical to a `response_segments` entry, so live events and reloaded segments render through the same code path. Persist these (they resolve the preceding spinner).
+
+Each tool beat streams as: `thinking` spinner → `changes` (if the workflow was modified) → `status` settled line → narration text.
 
 - **`attachments`** (array): Artifacts produced during this turn. Each entry has a `type` and `content` field. An empty list `[]` means no artifacts were produced (e.g. a purely informational response). The only supported type is `workflow_yaml`: the full workflow YAML with any job code changes stitched in. Job code edits are never returned separately — the YAML is the single source of truth, which allows multi-step changes in one response.
 

--- a/services/global_chat/README.md
+++ b/services/global_chat/README.md
@@ -70,6 +70,12 @@ Request to build a new multi-step workflow from scratch:
 ```json
 {
   "response": "I've created a workflow that fetches patient data from CommCare and loads it to DHIS2. The first job retrieves patient records via the CommCare REST API, and the second job maps and uploads them to DHIS2.",
+  "response_segments": [
+    { "type": "text", "content": "I'll build the workflow structure first." },
+    { "type": "status", "content": "Built workflow outline" },
+    { "type": "status", "content": "Wrote code for \"Fetch from CommCare\", \"Load to DHIS2\"" },
+    { "type": "text", "content": "I've created a workflow that fetches patient data from CommCare and loads it to DHIS2..." }
+  ],
   "attachments": [
     {
       "type": "workflow_yaml",
@@ -106,12 +112,18 @@ Request to build a new multi-step workflow from scratch:
 
 **Response Fields:**
 
-- `response`: The assistant's text response to the user
+- `response`: The assistant's text response to the user — the final answer. On
+  the planner path this is the last round's text only; earlier narration lives
+  in `response_segments`
+- `response_segments`: The durable transcript of the turn in stream order —
+  `text` segments woven with settled `status` lines ("Edited workflow
+  structure"). Transient "...ing" spinners are not included. See
+  `PAYLOAD_SPEC.md` for the full streaming event contract
 - `attachments`: Artifacts produced — currently always
   `{type: "workflow_yaml", content: string}` when YAML was generated or modified
-- `history`: Updated conversation history including the latest exchange. Direct
-  routes return string `content`; the planner path may return `content` as
-  Anthropic content-block arrays (`tool_use`/`tool_result`)
+- `history`: Updated conversation history including the latest exchange.
+  `content` is a string on every route; on the planner path the assistant entry
+  contains only the final answer text
 - `usage`: Aggregated token usage across all agents called during the request
 - `meta.agents`: Ordered list of agents invoked (e.g.
   `["router", "workflow_agent"]` or
@@ -151,7 +163,7 @@ For straightforward requests, the router calls subagents directly:
 
 ### Planner
 
-For complex requests, the `PlannerAgent` (Claude Sonnet) runs an agentic
+For complex requests, the `PlannerAgent` (Claude Opus) runs an agentic
 tool-calling loop with access to four tools:
 
 - **`call_workflow_agent`** — create or modify workflow YAML structure
@@ -165,7 +177,7 @@ then calls `call_job_code_agent` for each job that needs code. Job code is
 stitched into the workflow YAML immediately after each call.
 
 The loop continues until the model signals it is done (up to a configurable
-maximum of tool calls, default 25).
+maximum of tool calls, currently 10 in `config.yaml`).
 
 ## Testing
 

--- a/services/global_chat/global_chat.py
+++ b/services/global_chat/global_chat.py
@@ -108,6 +108,7 @@ def main(data_dict: dict) -> dict:
             # 5. Return structured response
             return {
                 "response": result.response,
+                "response_segments": result.response_segments,
                 "attachments": result.attachments,
                 "history": result.history,
                 "usage": result.usage,

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -38,6 +38,7 @@ class PlannerResult:
     """Result from planner run."""
 
     response: str
+    response_segments: List[Dict]
     attachments: List[Dict]
     history: List[Dict]
     usage: Dict
@@ -66,6 +67,7 @@ class PlannerAgent:
 
         self.current_yaml: Optional[str] = None
         self.subagent_results = []
+        self._segments: List[Dict] = []
 
         logger.info(f"PlannerAgent initialized with model: {self.model}")
 
@@ -95,16 +97,18 @@ class PlannerAgent:
         """
         logger.info("Planner.run() called")
 
-        stream_manager = StreamManager(model=self.model, stream=stream)
-        if workflow_yaml:
-            stream_manager.send_thinking(STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
-        else:
-            stream_manager.send_thinking(STATUS_NEW_WORKFLOW + STATUS_PLANNING)
-
         self.current_yaml = workflow_yaml
         self.yaml_modified = False
         self._user = user
         self._metrics_opt_in = metrics_opt_in
+        self._sent_yaml: Optional[str] = None
+        self._segments: List[Dict] = []
+
+        stream_manager = StreamManager(model=self.model, stream=stream)
+        if workflow_yaml:
+            self._send_status(stream_manager, STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
+        else:
+            self._send_status(stream_manager, STATUS_NEW_WORKFLOW + STATUS_PLANNING)
 
         system_prompt = self._build_system_prompt()
 
@@ -121,12 +125,10 @@ class PlannerAgent:
             "cache_read_input_tokens": 0,
         }
 
-        final_text = ""
-
         try:
             while tool_call_count < self.max_tool_calls:
                 try:
-                    response, buffered_text = self._call_api(system_prompt, messages, stream)
+                    response = self._call_api(system_prompt, messages, stream, stream_manager)
 
                     for field in [
                         "input_tokens",
@@ -138,17 +140,19 @@ class PlannerAgent:
 
                     logger.info(f"Claude API call {tool_call_count + 1}: stop_reason={response.stop_reason}")
 
+                    # Text from every round is part of the answer the user saw
+                    # (tool rounds may narrate before calling tools).
+                    round_text = self._extract_text(response)
+                    if round_text:
+                        self._segments.append({"type": "text", "content": round_text})
+
                     if response.stop_reason == "end_turn":
-                        # Send final YAML before text, matching workflow_chat/job_chat pattern
-                        if self.yaml_modified and self.current_yaml:
-                            stream_manager.send_changes({"yaml": self.current_yaml})
+                        # Covers non-streaming mode and the no-text edge case;
+                        # when streaming, the YAML was already sent before the
+                        # first text delta.
+                        self._send_pending_yaml(stream_manager)
 
-                        # Flush buffered text chunks
-                        for chunk in buffered_text:
-                            stream_manager.send_text(chunk)
-
-                        final_text = self._extract_text(response)
-                        messages.append({"role": "assistant", "content": final_text})
+                        messages.append({"role": "assistant", "content": round_text})
                         logger.info(f"Tool loop completed. Total calls: {tool_call_count}")
                         break
 
@@ -196,10 +200,19 @@ class PlannerAgent:
                     raise ApolloError(500, f"Tool execution error: {str(e)}")
 
             if response.stop_reason != "end_turn":
-                final_text = self._extract_text(response)
                 logger.warning(f"Loop exited without end_turn (reason: {response.stop_reason})")
         finally:
             stream_manager.end_stream()
+
+        # The full transcript in stream order: text segments (one per round)
+        # interleaved with the status messages shown between them, so the
+        # client can persist and re-render the woven view.
+        response_segments = self._segments
+
+        # response and history keep only the last round's text (the actual
+        # answer), matching the direct routes and what was saved before
+        # narration was streamed. The narration survives in response_segments.
+        final_text = round_text
 
         if not final_text:
             stop_reason = getattr(response, "stop_reason", None)
@@ -241,6 +254,7 @@ class PlannerAgent:
 
         return PlannerResult(
             response=final_text,
+            response_segments=response_segments,
             attachments=attachments,
             history=return_history,
             usage=total_usage,
@@ -274,8 +288,14 @@ class PlannerAgent:
 
         return user_content
 
-    def _call_api(self, system_prompt, messages, stream):
-        """Make Claude API call. When streaming, buffers text deltas for the caller to flush.
+    def _call_api(self, system_prompt, messages, stream, stream_manager):
+        """Make Claude API call. When streaming, forwards text deltas live.
+
+        All text blocks stream to the client as they generate — including the
+        narration the model writes before tool calls. Each round's text lands
+        in its own content block (the status and changes events sent between
+        rounds close the open text block), so the client can weave text and
+        status events with its own formatting.
 
         Adaptive thinking is enabled for better reasoning but thinking content
         is not streamed to the client — it exposes internal details like tool
@@ -283,8 +303,6 @@ class PlannerAgent:
         task-specific status messages sent before each tool execution.
         """
         if stream:
-            buffered_text = []
-
             with self.client.messages.stream(
                 model=self.model,
                 max_tokens=self.max_tokens,
@@ -295,10 +313,9 @@ class PlannerAgent:
                 output_config={"effort": "medium"},
             ) as stream_obj:
                 for event in stream_obj:
-                    if event.type == "content_block_delta":
-                        if event.delta.type == "text_delta":
-                            buffered_text.append(event.delta.text)
-                return stream_obj.get_final_message(), buffered_text
+                    if event.type == "content_block_delta" and event.delta.type == "text_delta":
+                        self._forward_text_delta(event.delta.text, stream_manager)
+                return stream_obj.get_final_message()
         else:
             response = self.client.beta.messages.create(
                 model=self.model,
@@ -325,7 +342,27 @@ class PlannerAgent:
                     ]
                 },
             )
-            return response, []
+            return response
+
+    def _forward_text_delta(self, text: str, stream_manager) -> None:
+        """Stream one text delta, sending any pending YAML first.
+
+        The client renders workflow changes before the text that references
+        them, so any YAML modified since the last send goes out first.
+        """
+        self._send_pending_yaml(stream_manager)
+        stream_manager.send_text(text)
+
+    def _send_pending_yaml(self, stream_manager) -> None:
+        """Send the current YAML as a changes event if it hasn't been sent yet."""
+        if self.yaml_modified and self.current_yaml and self.current_yaml != self._sent_yaml:
+            stream_manager.send_changes({"yaml": self.current_yaml})
+            self._sent_yaml = self.current_yaml
+
+    def _send_status(self, stream_manager, status: str | list[str]) -> None:
+        """Send a status message and record it as a response segment."""
+        sent = stream_manager.send_thinking(status)
+        self._segments.append({"type": "status", "content": sent})
 
     def _find_all_tool_uses(self, content):
         """Find all tool_use blocks in response content."""
@@ -478,7 +515,7 @@ class PlannerAgent:
         tool_results = []
 
         for tool_use_block in other_blocks:
-            stream_manager.send_thinking(self._tool_status_message(tool_use_block))
+            self._send_status(stream_manager, self._tool_status_message(tool_use_block))
             tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
             tool_results.append(
                 {"type": "tool_result", "tool_use_id": tool_use_block.id, "content": tool_result}
@@ -506,7 +543,7 @@ class PlannerAgent:
             status = f"Writing code for {joined}..."
         else:
             status = "Writing job code..."
-        stream_manager.send_thinking(status)
+        self._send_status(stream_manager, status)
 
         # Validate and prepare — skip invalid ones before launching threads.
         # matched_keys carries the YAML key resolved by find_job_in_yaml's
@@ -668,12 +705,8 @@ class PlannerAgent:
         return name.replace("-", " ").replace("_", " ").title()
 
     def _extract_text(self, response):
-        """Extract text from response content."""
-        text = ""
-        for block in response.content:
-            if block.type == "text":
-                text += block.text
-        return text
+        """Extract text from response content, concatenated as it was streamed."""
+        return "".join(block.text for block in response.content if block.type == "text")
 
     def _build_system_prompt(self) -> list:
         """Build system prompt for planner with cache control."""

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -359,10 +359,21 @@ class PlannerAgent:
             stream_manager.send_changes({"yaml": self.current_yaml})
             self._sent_yaml = self.current_yaml
 
-    def _send_status(self, stream_manager, status: str | list[str]) -> None:
-        """Send a status message and record it as a response segment."""
+    def _send_status(self, stream_manager, status: str | list[str] | None, record: bool = False) -> None:
+        """Send a status message.
+
+        Spinners ("...ing") are sent live but NOT recorded (record=False): the
+        client collapses consecutive statuses, so each spinner is replaced by
+        the settled past-tense line sent once the action finishes. Only the
+        settled line is recorded (record=True), so `response_segments` carries
+        just those lines and re-renders the same collapsed view on reload. A
+        None status is a no-op (an action that left nothing worth showing).
+        """
+        if status is None:
+            return
         sent = stream_manager.send_thinking(status)
-        self._segments.append({"type": "status", "content": sent})
+        if record:
+            self._segments.append({"type": "status", "content": sent})
 
     def _find_all_tool_uses(self, content):
         """Find all tool_use blocks in response content."""
@@ -516,7 +527,11 @@ class PlannerAgent:
 
         for tool_use_block in other_blocks:
             self._send_status(stream_manager, self._tool_status_message(tool_use_block))
+            yaml_before = self.current_yaml
             tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
+            self._send_status(
+                stream_manager, self._settled_status_message(tool_use_block, yaml_before), record=True
+            )
             tool_results.append(
                 {"type": "tool_result", "tool_use_id": tool_use_block.id, "content": tool_result}
             )
@@ -605,6 +620,7 @@ class PlannerAgent:
 
         # Stitch results and update state sequentially
         tool_results = []
+        stitched_names = []
         for block in blocks:
             if block.id in skipped:
                 tool_results.append(
@@ -632,6 +648,7 @@ class PlannerAgent:
                 self.current_yaml = stitch_job_code(self.current_yaml, matched_job_key, suggested_code)
                 self.yaml_modified = True
                 stitched = True
+                stitched_names.append(self._display_name_for_job(matched_job_key))
                 logger.info(f"Stitched code for job '{matched_job_key}' into current_yaml")
 
             self.subagent_results.append(subagent_result)
@@ -648,6 +665,13 @@ class PlannerAgent:
                 {"type": "tool_result", "tool_use_id": block.id, "content": tool_result}
             )
 
+        # Settle the spinner with the steps that were actually applied (drop any
+        # that failed to stitch); nothing recorded if none applied.
+        applied = [n for n in stitched_names if n]
+        if applied:
+            joined = ", ".join(f"\"{n}\"" for n in applied)
+            self._send_status(stream_manager, f"Wrote code for {joined}", record=True)
+
         return tool_results
 
     def _tool_status_message(self, tool_use_block) -> str:
@@ -663,7 +687,7 @@ class PlannerAgent:
 
         if name == "call_workflow_agent":
             if self.current_yaml:
-                return "Editing workflow..."
+                return "Reviewing the workflow..."
             return "Building workflow outline..."
 
         if name == "call_job_code_agent":
@@ -682,6 +706,38 @@ class PlannerAgent:
             return "Reading job code..."
 
         return f"Running {name}..."
+
+    def _settled_status_message(self, tool_use_block, yaml_before: str | None) -> str | None:
+        """Past-tense line that resolves the spinner for a finished tool call.
+
+        Counterpart to _tool_status_message. For workflow edits the outcome is
+        read from whether the YAML actually changed: an unchanged workflow means
+        the agent only advised (or errored), so it settles to "Analyzed the
+        workflow" rather than claiming an edit. Returns None when there's
+        nothing worth persisting. Job-code settling is handled where the code is
+        stitched, since it depends on which steps were applied.
+        """
+        name = tool_use_block.name
+        inputs = tool_use_block.input or {}
+
+        if name == "call_workflow_agent":
+            if self.current_yaml == yaml_before:
+                return "Analyzed the workflow"
+            return "Edited workflow structure" if yaml_before else "Built workflow outline"
+
+        if name == "search_documentation":
+            query = inputs.get("query")
+            return f"Searched documentation for \"{query}\"" if query else "Searched documentation"
+
+        if name == "inspect_job_code":
+            job_keys = inputs.get("job_keys") or ([inputs["job_key"]] if inputs.get("job_key") else [])
+            names = [n for n in (self._display_name_for_job(k) for k in job_keys) if n]
+            if names:
+                joined = ", ".join(f"\"{n}\"" for n in names)
+                return f"Read code for {joined}"
+            return "Read code"
+
+        return None
 
     def _display_name_for_job(self, job_key: str | None) -> str | None:
         """Look up a human-readable display name for a job key.

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -101,14 +101,13 @@ class PlannerAgent:
         self.yaml_modified = False
         self._user = user
         self._metrics_opt_in = metrics_opt_in
-        self._sent_yaml: Optional[str] = None
         self._segments: List[Dict] = []
 
         stream_manager = StreamManager(model=self.model, stream=stream)
         if workflow_yaml:
-            self._send_status(stream_manager, STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
+            self._send_spinner(stream_manager, STATUS_REVIEWING_WORKFLOW + STATUS_PLANNING)
         else:
-            self._send_status(stream_manager, STATUS_NEW_WORKFLOW + STATUS_PLANNING)
+            self._send_spinner(stream_manager, STATUS_NEW_WORKFLOW + STATUS_PLANNING)
 
         system_prompt = self._build_system_prompt()
 
@@ -147,11 +146,6 @@ class PlannerAgent:
                         self._segments.append({"type": "text", "content": round_text})
 
                     if response.stop_reason == "end_turn":
-                        # Covers non-streaming mode and the no-text edge case;
-                        # when streaming, the YAML was already sent before the
-                        # first text delta.
-                        self._send_pending_yaml(stream_manager)
-
                         messages.append({"role": "assistant", "content": round_text})
                         logger.info(f"Tool loop completed. Total calls: {tool_call_count}")
                         break
@@ -314,7 +308,7 @@ class PlannerAgent:
             ) as stream_obj:
                 for event in stream_obj:
                     if event.type == "content_block_delta" and event.delta.type == "text_delta":
-                        self._forward_text_delta(event.delta.text, stream_manager)
+                        stream_manager.send_text(event.delta.text)
                 return stream_obj.get_final_message()
         else:
             response = self.client.beta.messages.create(
@@ -344,42 +338,46 @@ class PlannerAgent:
             )
             return response
 
-    def _forward_text_delta(self, text: str, stream_manager) -> None:
-        """Stream one text delta, sending any pending YAML first.
+    def _send_yaml(self, stream_manager) -> None:
+        """Stream the current YAML as a changes event.
 
-        The client renders workflow changes before the text that references
-        them, so any YAML modified since the last send goes out first.
+        Called wherever the YAML is actually updated (workflow edit, job-code
+        stitch), so each change reaches the client the moment it happens — e.g.
+        a newly added step renders before its code is written. No-op in
+        non-streaming mode, where the final payload's attachment carries the
+        YAML instead.
         """
-        self._send_pending_yaml(stream_manager)
-        stream_manager.send_text(text)
+        stream_manager.send_changes({"yaml": self.current_yaml})
 
-    def _send_pending_yaml(self, stream_manager) -> None:
-        """Send the current YAML as a changes event if it hasn't been sent yet."""
-        if self.yaml_modified and self.current_yaml and self.current_yaml != self._sent_yaml:
-            stream_manager.send_changes({"yaml": self.current_yaml})
-            self._sent_yaml = self.current_yaml
+    def _send_spinner(self, stream_manager, status: str | list[str]) -> None:
+        """Send a transient "...ing" spinner as a thinking event.
 
-    def _send_status(self, stream_manager, status: str | list[str] | None, record: bool = False) -> None:
-        """Send a status message.
-
-        Spinners ("...ing") are sent live but NOT recorded (record=False): the
-        client collapses consecutive statuses, so each spinner is replaced by
-        the settled past-tense line sent once the action finishes. Only the
-        settled line is recorded (record=True), so `response_segments` carries
-        just those lines and re-renders the same collapsed view on reload. A
-        None status is a no-op (an action that left nothing worth showing).
+        Thinking events are live progress only: the client replaces each one
+        with the next status and never persists them, so spinners are not
+        recorded in the transcript.
         """
-        if status is None:
+        stream_manager.send_thinking(status)
+
+    def _send_settled(self, stream_manager, content: str | None) -> None:
+        """Send a completed-action line ("Edited workflow structure") as a
+        custom `status` event and record it in the transcript.
+
+        Unlike spinners, these are durable facts about what happened: the
+        client persists them (they resolve the preceding spinner), and they
+        are recorded in `response_segments` so a page reload re-renders the
+        same view. None means the action left nothing worth showing (e.g. a
+        consult that changed nothing) — nothing is sent or recorded.
+        """
+        if not content:
             return
-        sent = stream_manager.send_thinking(status)
-        if record:
-            self._segments.append({"type": "status", "content": sent})
+        stream_manager.send_status(content)
+        self._segments.append({"type": "status", "content": content})
 
     def _find_all_tool_uses(self, content):
         """Find all tool_use blocks in response content."""
         return [block for block in content if block.type == "tool_use"]
 
-    def _execute_tool(self, tool_use_block, total_usage, tool_calls_meta) -> str:
+    def _execute_tool(self, tool_use_block, stream_manager, total_usage, tool_calls_meta) -> str:
         """Execute a single tool call and return the result string."""
         if tool_use_block.name == "search_documentation":
             tool_result = search_documentation_tool(tool_use_block.input)
@@ -403,10 +401,11 @@ class PlannerAgent:
             if "usage" in subagent_result:
                 total_usage.update(sum_usage(total_usage, subagent_result["usage"]))
 
-            # Update live state eagerly
+            # Update live state and stream the change in the same breath
             if subagent_result.get("response_yaml"):
                 self.current_yaml = subagent_result["response_yaml"]
                 self.yaml_modified = True
+                self._send_yaml(stream_manager)
 
             self.subagent_results.append(subagent_result)
 
@@ -468,6 +467,7 @@ class PlannerAgent:
                 self.current_yaml = stitch_job_code(self.current_yaml, matched_job_key, suggested_code)
                 self.yaml_modified = True
                 stitched = True
+                self._send_yaml(stream_manager)
                 logger.info(f"Stitched code for job '{matched_job_key}' into current_yaml")
 
             self.subagent_results.append(subagent_result)
@@ -526,12 +526,10 @@ class PlannerAgent:
         tool_results = []
 
         for tool_use_block in other_blocks:
-            self._send_status(stream_manager, self._tool_status_message(tool_use_block))
+            self._send_spinner(stream_manager, self._tool_status_message(tool_use_block))
             yaml_before = self.current_yaml
-            tool_result = self._execute_tool(tool_use_block, total_usage, tool_calls_meta)
-            self._send_status(
-                stream_manager, self._settled_status_message(tool_use_block, yaml_before), record=True
-            )
+            tool_result = self._execute_tool(tool_use_block, stream_manager, total_usage, tool_calls_meta)
+            self._send_settled(stream_manager, self._settled_status_message(tool_use_block, yaml_before))
             tool_results.append(
                 {"type": "tool_result", "tool_use_id": tool_use_block.id, "content": tool_result}
             )
@@ -558,7 +556,7 @@ class PlannerAgent:
             status = f"Writing code for {joined}..."
         else:
             status = "Writing job code..."
-        self._send_status(stream_manager, status)
+        self._send_spinner(stream_manager, status)
 
         # Validate and prepare — skip invalid ones before launching threads.
         # matched_keys carries the YAML key resolved by find_job_in_yaml's
@@ -666,11 +664,12 @@ class PlannerAgent:
             )
 
         # Settle the spinner with the steps that were actually applied (drop any
-        # that failed to stitch); nothing recorded if none applied.
-        applied = [n for n in stitched_names if n]
-        if applied:
-            joined = ", ".join(f"\"{n}\"" for n in applied)
-            self._send_status(stream_manager, f"Wrote code for {joined}", record=True)
+        # that failed to stitch); nothing sent if none applied. One YAML send
+        # covers the whole batch, mirroring the one combined status.
+        if stitched_names:
+            self._send_yaml(stream_manager)
+            joined = ", ".join(f"\"{n}\"" for n in stitched_names)
+            self._send_settled(stream_manager, f"Wrote code for {joined}")
 
         return tool_results
 

--- a/services/global_chat/router.py
+++ b/services/global_chat/router.py
@@ -40,6 +40,7 @@ class RouterResult:
     """Result from router or passthrough."""
 
     response: str
+    response_segments: List[Dict]
     attachments: List[Dict]
     history: List[Dict]
     usage: Dict
@@ -258,6 +259,7 @@ class RouterAgent:
 
         return RouterResult(
             response=result["response"],
+            response_segments=[{"type": "text", "content": result["response"]}],
             attachments=attachments,
             history=result["history"].copy(),
             usage=total_usage,
@@ -360,6 +362,7 @@ class RouterAgent:
 
         return RouterResult(
             response=result["response"],
+            response_segments=[{"type": "text", "content": result["response"]}],
             attachments=attachments,
             history=result["history"].copy(),
             usage=total_usage,
@@ -401,6 +404,7 @@ class RouterAgent:
 
         return RouterResult(
             response=planner_result.response,
+            response_segments=planner_result.response_segments,
             attachments=planner_result.attachments,
             history=planner_result.history,
             usage=total_usage,

--- a/services/global_chat/tests/unit/test_planner.py
+++ b/services/global_chat/tests/unit/test_planner.py
@@ -22,6 +22,7 @@ def make_planner() -> PlannerAgent:
     planner.current_yaml = WORKFLOW_YAML
     planner.yaml_modified = False
     planner.subagent_results = []
+    planner._segments = []
     planner.api_key = "test-key"
     planner._user = None
     planner._metrics_opt_in = None

--- a/services/global_chat/tests/unit/test_planner.py
+++ b/services/global_chat/tests/unit/test_planner.py
@@ -49,12 +49,18 @@ class StubStreamManager:
     def send_thinking(self, *_args: object, **_kwargs: object) -> None:
         pass
 
+    def send_changes(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def send_status(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
 
 def test_inspect_job_code_accepts_multiple_keys() -> None:
     planner = make_planner()
     block = FakeToolUse("inspect_job_code", {"job_keys": ["fetch-patients", "missing-step"]})
 
-    result = planner._execute_tool(block, empty_usage(), [])
+    result = planner._execute_tool(block, StubStreamManager(), empty_usage(), [])
 
     assert "get('/patients');" in result
     assert "No code found for job 'missing-step'" in result
@@ -66,7 +72,7 @@ def test_job_agent_failure_returns_error_tool_result() -> None:
     meta = []
 
     with patch("global_chat.planner.call_job_agent", side_effect=RuntimeError("boom")):
-        result = planner._execute_tool(block, empty_usage(), meta)
+        result = planner._execute_tool(block, StubStreamManager(), empty_usage(), meta)
 
     assert result.startswith("ERROR: The job code agent failed: boom")
     assert meta[0]["error"] == "boom"
@@ -77,7 +83,7 @@ def test_workflow_agent_failure_returns_error_tool_result() -> None:
     block = FakeToolUse("call_workflow_agent", {"message": "add a step"})
 
     with patch("global_chat.planner.call_workflow_agent", side_effect=RuntimeError("boom")):
-        result = planner._execute_tool(block, empty_usage(), [])
+        result = planner._execute_tool(block, StubStreamManager(), empty_usage(), [])
 
     assert result.startswith("ERROR: The workflow agent failed: boom")
     assert planner.current_yaml == WORKFLOW_YAML
@@ -90,7 +96,7 @@ def test_job_code_without_matched_key_is_reported_as_not_stitched() -> None:
     subagent_result = {"response": "done", "suggested_code": "newCode();", "usage": empty_usage()}
 
     with patch("global_chat.planner.call_job_agent", return_value=subagent_result):
-        result = planner._execute_tool(block, empty_usage(), [])
+        result = planner._execute_tool(block, StubStreamManager(), empty_usage(), [])
 
     assert "NOT added to the workflow" in result
     assert "stitched into the workflow" not in result
@@ -105,7 +111,7 @@ def test_workflow_agent_yaml_response_updates_structure_view() -> None:
     subagent_result = {"response": "Added the step.", "response_yaml": new_yaml, "usage": empty_usage()}
 
     with patch("global_chat.planner.call_workflow_agent", return_value=subagent_result):
-        result = planner._execute_tool(block, empty_usage(), [])
+        result = planner._execute_tool(block, StubStreamManager(), empty_usage(), [])
 
     assert "Updated workflow structure:" in result
     assert "new-step" in result
@@ -119,7 +125,7 @@ def test_workflow_agent_without_yaml_reports_no_change() -> None:
     subagent_result = {"response": "Which DHIS2 instance?", "response_yaml": None, "usage": empty_usage()}
 
     with patch("global_chat.planner.call_workflow_agent", return_value=subagent_result):
-        result = planner._execute_tool(block, empty_usage(), [])
+        result = planner._execute_tool(block, StubStreamManager(), empty_usage(), [])
 
     assert "[No workflow changes were made — no YAML was produced.]" in result
     assert "Updated workflow structure:" not in result

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -164,7 +164,7 @@ class StreamManager:
         self,
         thinking_text: str | list[str],
         signature: str | None = "signature_filler",
-    ) -> str:
+    ) -> None:
         """
         Send a thinking block with the given text.
         Creates a new content block, sends the thinking, and closes it.
@@ -174,10 +174,6 @@ class StreamManager:
                 one entry is picked at random — convenient for rotating
                 through status message pools.
             signature: Optional signature to include with the thinking
-
-        Returns:
-            The text that was sent (the picked entry when a list was passed),
-            so callers can record what the client actually saw.
         """
         if self.stream_ended:
             raise RuntimeError("Stream already ended")
@@ -315,6 +311,24 @@ class StreamManager:
 
         self._close_open_blocks()
         self._emit_event('changes', changes_data)
+
+    def send_status(self, content: str) -> None:
+        """
+        Send a completed-action status ("Edited workflow structure") as a
+        custom `status` SSE event.
+
+        This is deliberately a different event type from the transient
+        spinners sent via send_thinking: thinking events are live progress
+        that the client replaces and never persists, while `status` events
+        are durable facts about what happened, which the client keeps. The
+        payload matches the `response_segments` entry shape so the client
+        can render live events and reloaded segments with the same code.
+        """
+        if not self.stream_started:
+            self.start_stream()
+
+        self._close_open_blocks()
+        self._emit_event('status', {"type": "status", "content": content})
 
     def end_stream(self, stop_reason: str = "end_turn") -> None:
         """

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -214,8 +214,6 @@ class StreamManager:
 
         self._close_block(block)
 
-        return thinking_text
-
     def start_thinking_block(self) -> None:
         """
         Start a new thinking block for incremental streaming.

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -164,7 +164,7 @@ class StreamManager:
         self,
         thinking_text: str | list[str],
         signature: str | None = "signature_filler",
-    ) -> None:
+    ) -> str:
         """
         Send a thinking block with the given text.
         Creates a new content block, sends the thinking, and closes it.
@@ -174,6 +174,10 @@ class StreamManager:
                 one entry is picked at random — convenient for rotating
                 through status message pools.
             signature: Optional signature to include with the thinking
+
+        Returns:
+            The text that was sent (the picked entry when a list was passed),
+            so callers can record what the client actually saw.
         """
         if self.stream_ended:
             raise RuntimeError("Stream already ended")
@@ -213,6 +217,8 @@ class StreamManager:
         })
 
         self._close_block(block)
+
+        return thinking_text
 
     def start_thinking_block(self) -> None:
         """


### PR DESCRIPTION
## Short Description

The planner buffered all model text and flushed it only after the response finished. Users saw nothing while the planner worked. Text the model wrote before tool calls ("I'll build this for you...") was silently discarded. Now we stream the planner's narration text live and separate its progress messages into two event types: transient "...ing" spinners (thinking events) and a new custom `status` event for completed actions ("Edited workflow structure"), which also persist in a new `response_segments` field. Workflow YAML now streams the moment it changes instead of waiting for the next text.

Fixes #572 

Matching Lightning PR: https://github.com/OpenFn/lightning/pull/4969

## Implementation Details

Previously the planner buffered all text and sent it at the end, and every status was a thinking event with nothing to distinguish an in-progress spinner from a completed action. Lightning had no reliable way to know which statuses to persist, and the transcript could not be re-rendered after a page reload.

- Text deltas now stream as they generate, including the narration the model writes before tool calls.
- Each tool call sends a spinner ("Reviewing the workflow...") as a thinking event, then a past-tense settled line as a new custom `status` SSE event once the action completes. The settled verb reflects the actual outcome: a workflow-agent call that returned no YAML settles to "Analyzed the workflow" rather than claiming an edit, and job-code lines only count steps that were actually stitched in. Apollo owns this classification so Lightning just maps event type to visual treatment (spinners replace each other and vanish; status events persist).
- A new `response_segments` output field records the durable transcript (text woven with settled status lines, spinners excluded) so the frontend can re-render the same view on reload. The `status` event payload matches the segment shape, so one render path covers both.
- The YAML `changes` event is now sent inside the update itself, wherever `current_yaml` changes (workflow edit or job-code stitch), instead of being checked before every text delta. A newly added step reaches the client before its code is written, and the per-token change-detection machinery (`_sent_yaml`, pending-send checks) is deleted.
- Planner history now returns plain string content on every route, matching the direct routes.

## AI Usage

Please disclose whether you've used AI in this work (it's cool, we just want to
know!):

- [x] Yes, I have not used AI
- [ ] No, I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
