### PR TITLE
Add langfuse original workflow

### DIFF
--- a/.changeset/good-months-tease.md
+++ b/.changeset/good-months-tease.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+add generation diff metadata for langfuse

--- a/services/global_chat/global_chat.py
+++ b/services/global_chat/global_chat.py
@@ -14,7 +14,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 
 from langfuse import observe, propagate_attributes, get_client as get_langfuse_client
 from util import ApolloError, create_logger, APOLLO_VERSION
-from langfuse_util import should_track, build_tags
+from langfuse_util import should_track, build_tags, build_generation_diff
 from global_chat.config_loader import ConfigLoader
 from global_chat.router import RouterAgent
 
@@ -104,6 +104,20 @@ def main(data_dict: dict) -> dict:
                 user=user_info,
                 metrics_opt_in=data.metrics_opt_in,
             )
+
+            if tracking:
+                final_yaml = next(
+                    (a.get("content") for a in reversed(result.attachments or [])
+                     if a.get("type") == "workflow_yaml"),
+                    None,
+                )
+                diff_meta = build_generation_diff(
+                    original=data.workflow_yaml,
+                    generated=final_yaml,
+                    yaml_mode=True,
+                )
+                if diff_meta:
+                    langfuse.update_current_span(metadata=diff_meta)
 
             # 5. Return structured response
             return {

--- a/services/global_chat/tests/test_langfuse_util.py
+++ b/services/global_chat/tests/test_langfuse_util.py
@@ -5,7 +5,7 @@ from pathlib import Path
 services_dir = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(services_dir))
 
-from langfuse_util import should_track, build_tags  # noqa: E402, I001
+from langfuse_util import should_track, build_tags, build_generation_diff  # noqa: E402, I001
 
 
 def test_metrics_opt_in_true_is_tracked() -> None:
@@ -44,3 +44,49 @@ def test_build_tags_includes_persona() -> None:
 def test_build_tags_without_persona() -> None:
     assert build_tags("global_chat", {}) == ["global_chat"]
     assert build_tags("global_chat", None) == ["global_chat"]
+
+
+def test_diff_none_when_nothing_generated() -> None:
+    assert build_generation_diff("fn(s => s);", None) is None
+    assert build_generation_diff("fn(s => s);", "") is None
+
+
+def test_diff_marks_only_generated_lines_as_added() -> None:
+    original = "get('/patients');\n\nfn(state => {\n  console.log(state.data);\n  return state;\n});"
+    generated = "get('/patients');\n\nfn(state => {\n  console.log(state.data);\n  if (!state.data) {\n    throw new Error('no data');\n  }\n  return state;\n});"
+    meta = build_generation_diff(original, generated)
+    diff = meta["generation_diff"]
+    # Pre-existing user quirk appears as context, not as generated
+    assert "   console.log(state.data);" in diff.splitlines()
+    assert "+  console.log(state.data);" not in diff
+    assert "+  if (!state.data) {" in diff
+    assert meta["diff_stats"] == {"lines_added": 3, "lines_removed": 0}
+
+
+def test_diff_from_scratch_when_no_original() -> None:
+    meta = build_generation_diff(None, "fn(s => s);")
+    assert meta["diff_stats"] == {"lines_added": 1, "lines_removed": 0}
+    assert "+fn(s => s);" in meta["generation_diff"]
+
+
+def test_yaml_mode_ignores_formatting_only_changes() -> None:
+    original = 'name: "wf"\njobs:\n  a:\n    adaptor: "@openfn/language-http@6.5.1"\n'
+    reserialized = "name: wf\njobs:\n  a:\n    adaptor: '@openfn/language-http@6.5.1'\n"
+    meta = build_generation_diff(original, reserialized, yaml_mode=True)
+    assert meta["generation_diff"] == ""
+    assert meta["diff_stats"] == {"lines_added": 0, "lines_removed": 0}
+
+
+def test_yaml_mode_diffs_job_bodies_line_by_line() -> None:
+    original = "jobs:\n  a:\n    body: \"get(x);\\nfn(s => s);\\n\"\n"
+    generated = "jobs:\n  a:\n    body: |\n      get(x);\n      fn(s => s);\n      post(y);\n"
+    meta = build_generation_diff(original, generated, yaml_mode=True)
+    # Both sides normalize to block scalars, so only the new line is added
+    assert meta["diff_stats"] == {"lines_added": 1, "lines_removed": 0}
+    assert "+      post(y);" in meta["generation_diff"]
+
+
+def test_yaml_mode_falls_back_to_raw_diff_on_invalid_yaml() -> None:
+    meta = build_generation_diff("{not: valid: yaml", "still generated", yaml_mode=True)
+    assert meta is not None
+    assert "+still generated" in meta["generation_diff"]

--- a/services/job_chat/job_chat.py
+++ b/services/job_chat/job_chat.py
@@ -18,7 +18,7 @@ from anthropic import (
 )
 import sentry_sdk
 from langfuse import observe, propagate_attributes, get_client as get_langfuse_client
-from langfuse_util import should_track, build_tags
+from langfuse_util import should_track, build_tags, build_generation_diff
 from util import ApolloError, create_logger, AdaptorSpecifier, add_page_prefix, APOLLO_VERSION
 from .prompt import build_prompt, build_error_correction_prompt
 from .old_prompt import build_old_prompt
@@ -674,6 +674,14 @@ def main(data_dict: dict) -> dict:
             if tracking and result.suggested_code:
                 with propagate_attributes(tags=["has_code_attachment"]):
                     pass
+
+            if tracking:
+                diff_meta = build_generation_diff(
+                    original=data.context.get("expression"),
+                    generated=result.suggested_code,
+                )
+                if diff_meta:
+                    langfuse.update_current_span(metadata=diff_meta)
 
             response_dict = {
                 "response": result.response,

--- a/services/langfuse_util.py
+++ b/services/langfuse_util.py
@@ -1,4 +1,7 @@
 """Langfuse tracking utilities for controlling trace export and tagging."""
+import difflib
+
+import yaml
 
 
 def should_track(data_dict: dict, force: bool = False) -> bool:
@@ -15,3 +18,75 @@ def build_tags(service_name: str, user_info: dict) -> list:
     if persona:
         tags.append(persona)
     return tags
+
+
+class _BlockScalarDumper(yaml.SafeDumper):
+    """Dumper that renders multi-line strings (job bodies) as literal blocks
+    so embedded code stays line-diffable."""
+
+
+def _represent_str(dumper: yaml.SafeDumper, value: str) -> yaml.ScalarNode:
+    style = "|" if "\n" in value else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+_BlockScalarDumper.add_representer(str, _represent_str)
+
+
+def _normalize_yaml(yaml_str: str) -> str:
+    """Re-serialize workflow YAML so both diff sides share one formatting.
+
+    The services round-trip YAML through safe_load/dump, so a raw diff of
+    input vs output would flag formatting-only changes (key order, quoting,
+    indentation) as generated. Falls back to the raw string if parsing fails.
+    """
+    try:
+        data = yaml.safe_load(yaml_str)
+    except Exception:
+        return yaml_str
+    if not isinstance(data, dict):
+        return yaml_str
+    return yaml.dump(data, Dumper=_BlockScalarDumper, sort_keys=False)
+
+
+def build_generation_diff(
+    original: str | None, generated: str | None, yaml_mode: bool = False,
+) -> dict | None:
+    """Build Langfuse trace metadata describing what the model wrote this turn.
+
+    Diffs the pre-existing artifact (job code or workflow YAML) against the
+    generated one, so evaluators can tell model output from pre-existing
+    (e.g. user-written) content. Returns None when nothing was generated.
+
+    Never raises: this runs inside production request handling, and a
+    monitoring failure must degrade to "no diff", not a failed response.
+    """
+    try:
+        if not generated:
+            return None
+
+        original = original or ""
+        if yaml_mode:
+            original = _normalize_yaml(original)
+            generated = _normalize_yaml(generated)
+
+        diff_lines = list(
+            difflib.unified_diff(
+                original.splitlines(),
+                generated.splitlines(),
+                fromfile="original",
+                tofile="generated",
+                n=5,
+                lineterm="",
+            ),
+        )
+        added = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+        removed = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+        return {
+            "generation_diff": "\n".join(diff_lines),
+            "diff_stats": {"lines_added": added, "lines_removed": removed},
+        }
+    except Exception as e:
+        # print, not create_logger: this must stay out of the user-facing stream
+        print(f"build_generation_diff failed, skipping diff metadata: {e}")  # noqa: T201
+        return None

--- a/services/workflow_chat/workflow_chat.py
+++ b/services/workflow_chat/workflow_chat.py
@@ -42,7 +42,7 @@ from anthropic import (
 )
 import sentry_sdk
 from langfuse import observe, propagate_attributes, get_client as get_langfuse_client
-from langfuse_util import should_track, build_tags
+from langfuse_util import should_track, build_tags, build_generation_diff
 from util import ApolloError, create_logger, add_page_prefix, APOLLO_VERSION
 from .gen_project_prompt import build_prompt
 from workflow_chat.available_adaptors import get_available_adaptors
@@ -688,6 +688,15 @@ def main(data_dict: dict) -> dict:
                 current_page=current_page,
                 read_only=data.read_only
             )
+
+            if tracking:
+                diff_meta = build_generation_diff(
+                    original=data.existing_yaml,
+                    generated=result.content_yaml,
+                    yaml_mode=True,
+                )
+                if diff_meta:
+                    langfuse.update_current_span(metadata=diff_meta)
 
             # Build response
             response_dict = {


### PR DESCRIPTION
## Short Description

Adds a `generation_diff` to the Langfuse trace metadata of `job_chat`, `workflow_chat` and `global_chat`, showing exactly what the model wrote in that turn versus what was already in the user's job code or workflow YAML.

Fixes #586 

## Implementation Details

**Problem.** Our Langfuse traces are evaluated for job code and workflow quality, but a trace only shows the final artifact. There is no way to tell which parts were generated in that turn and which were already there.

**Approach.** Each service now computes a unified diff between the original artifact from the request (job code from `context.expression`, workflow YAML from `existing_yaml` / `workflow_yaml`) and the generated one, and attaches it to the trace as metadata (`generation_diff` plus a small `diff_stats` count). A diff is the minimal representation that still shows everything needed: added lines are the model's work, context and removed lines are pre-existing. The original artifact itself is not stored, since it can always be reconstructed from the final output plus the diff.

**Only touches Langfuse metadata and not the response payload.** This is purely for observability, so it goes only on the trace via `update_current_span(metadata=...)`. Putting it in the response `meta` would bloat every payload back to Lightning with data Lightning does not use, and would change the public response shape. The Langfuse SDK flushes in the background, and the diff is computed after generation completes, so request latency is unaffected. Everything is gated on `metrics_opt_in`, so opted-out requests do no extra work.

## AI Usage

Please disclose whether you've used AI in this work (it's cool, we just want to
know!):

- [x] Yes, I have not used AI
- [ ] No, I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
