### PR TITLE
Langfuse add secrets cleanup to tracing

### DIFF
--- a/.changeset/tame-things-argue.md
+++ b/.changeset/tame-things-argue.md
@@ -1,0 +1,5 @@
+---
+"apollo": patch
+---
+
+clean up langfuse keys

--- a/services/entry.py
+++ b/services/entry.py
@@ -17,6 +17,7 @@ ThreadingInstrumentor().instrument()
 
 from langfuse import Langfuse
 from langfuse.span_filter import is_default_export_span
+from langfuse_util import mask_secrets
 
 
 def _should_export_span(span):
@@ -27,7 +28,11 @@ def _should_export_span(span):
     return is_default_export_span(span)
 
 
-langfuse = Langfuse(should_export_span=_should_export_span, release=os.getenv("APOLLO_VERSION", "unknown"))
+langfuse = Langfuse(
+    should_export_span=_should_export_span,
+    mask=mask_secrets,
+    release=os.getenv("APOLLO_VERSION", "unknown"),
+)
 
 env = os.getenv('ENVIRONMENT', 'unknown')
 trace_rates = {

--- a/services/global_chat/tests/test_langfuse_util.py
+++ b/services/global_chat/tests/test_langfuse_util.py
@@ -5,7 +5,7 @@ from pathlib import Path
 services_dir = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(services_dir))
 
-from langfuse_util import should_track, build_tags  # noqa: E402, I001
+from langfuse_util import should_track, build_tags, mask_secrets  # noqa: E402, I001
 
 
 def test_metrics_opt_in_true_is_tracked() -> None:
@@ -44,3 +44,38 @@ def test_build_tags_includes_persona() -> None:
 def test_build_tags_without_persona() -> None:
     assert build_tags("global_chat", {}) == ["global_chat"]
     assert build_tags("global_chat", None) == ["global_chat"]
+
+
+def test_mask_redacts_api_key_at_any_depth() -> None:
+    # Shape of @observe-captured input: {"args": [...], "kwargs": {...}}
+    data = {"args": ["question"], "kwargs": {"api_key": "sk-ant-abc123", "code": "fn(s => s);"}}
+    masked = mask_secrets(data)
+    assert masked["kwargs"]["api_key"] == "[REDACTED]"
+    assert masked["kwargs"]["code"] == "fn(s => s);"
+    assert masked["args"] == ["question"]
+
+
+def test_mask_redacts_all_secret_key_names() -> None:
+    data = {"anthropic_api_key": "abc", "Authorization": "Bearer xyz", "model": "claude"}
+    masked = mask_secrets(data)
+    assert masked["anthropic_api_key"] == "[REDACTED]"
+    assert masked["Authorization"] == "[REDACTED]"
+    assert masked["model"] == "claude"
+
+
+def test_mask_redacts_key_shaped_strings_in_free_text() -> None:
+    masked = mask_secrets("client = Anthropic(api_key='sk-ant-api03-xYz_9')")
+    assert "sk-ant" not in masked
+    assert masked == "client = Anthropic(api_key='[REDACTED]')"
+
+
+def test_mask_preserves_none_and_non_string_values() -> None:
+    assert mask_secrets({"api_key": None}) == {"api_key": None}
+    assert mask_secrets({"usage": {"input_tokens": 5}}) == {"usage": {"input_tokens": 5}}
+    number = 42
+    assert mask_secrets(number) == number
+
+
+def test_mask_traverses_lists() -> None:
+    data = [{"api_key": "secret"}, "plain text"]
+    assert mask_secrets(data) == [{"api_key": "[REDACTED]"}, "plain text"]

--- a/services/langfuse_util.py
+++ b/services/langfuse_util.py
@@ -1,4 +1,28 @@
 """Langfuse tracking utilities for controlling trace export and tagging."""
+import re
+from typing import Any
+
+_SECRET_KEY_NAMES = {"api_key", "anthropic_api_key", "authorization"}
+_SECRET_VALUE_PATTERN = re.compile(r"sk-ant-[\w\-]+")
+
+
+def mask_secrets(data: Any) -> Any:  # noqa: ANN401
+    """Langfuse mask callback: redact API keys from all traced data.
+
+    Applied by the SDK to every span's input, output and metadata before
+    export, so keys passed as function arguments to @observe-decorated
+    functions never reach Langfuse.
+    """
+    if isinstance(data, dict):
+        return {
+            k: "[REDACTED]" if str(k).lower() in _SECRET_KEY_NAMES and v else mask_secrets(v)
+            for k, v in data.items()
+        }
+    if isinstance(data, (list, tuple)):
+        return [mask_secrets(v) for v in data]
+    if isinstance(data, str):
+        return _SECRET_VALUE_PATTERN.sub("[REDACTED]", data)
+    return data
 
 
 def should_track(data_dict: dict, force: bool = False) -> bool:


### PR DESCRIPTION
## Short Description

Masks API keys in Langfuse trace exports. Some `@observe`-decorated functions take `api_key` as an argument, and Langfuse captures function arguments as span input, so keys were visible in traces.

## Implementation Details

- Adds a `mask_secrets` callback to the Langfuse client in `entry.py`. The SDK applies it to every span's input, output and metadata before export, so this covers all current spans and any future observed function that takes a key, with no per-function changes needed.
- It redacts values under key-like field names (`api_key`, `anthropic_api_key`, `authorization`) and any `sk-ant-...` shaped string in free text. Adds tests for the masking.

I also tried to fix this earlier but didn't apply it deep enough in the nested trace.

## AI Usage

Please disclose whether you've used AI in this work (it's cool, we just want to
know!):

- [x] Yes, I have not used AI
- [ ] No, I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
