### PR TITLE
Create DocsiteSearch embeddings lazily instead of at import time

### DIFF
--- a/.changeset/lazy-docsite-embeddings.md
+++ b/.changeset/lazy-docsite-embeddings.md
@@ -1,0 +1,7 @@
+---
+"apollo": patch
+---
+
+search_docsite: create the default OpenAIEmbeddings client lazily so
+importing the module (e.g. via global chat's tool imports) no longer
+crashes without OPENAI_API_KEY

--- a/services/search_docsite/search_docsite.py
+++ b/services/search_docsite/search_docsite.py
@@ -15,9 +15,15 @@ class DocsiteSearch:
     :param collection_name: Vectorstore collection name (namespace) to store documents
     :param index_name: Vectorstore index name (default: docsite)
     :param default_top_k: Default number of results to return (default: 5)
-    :param embeddings: LangChain embedding type (default: OpenAIEmbeddings())
+    :param embeddings: LangChain embedding type (default: OpenAIEmbeddings(), created lazily)
     """
-    def __init__(self, collection_name=None, index_name="docsite", default_top_k=5, embeddings=OpenAIEmbeddings()):
+    def __init__(self, collection_name=None, index_name="docsite", default_top_k=5, embeddings=None):
+        # OpenAIEmbeddings() must not be a default argument: defaults are
+        # evaluated at import time and it raises without OPENAI_API_KEY,
+        # which crashed any importer (e.g. global_chat's tool imports)
+        # even when docsite search was never used.
+        if embeddings is None:
+            embeddings = OpenAIEmbeddings()
         self.index_client = index_name
         self.default_top_k = default_top_k
 

--- a/services/search_docsite/tests/unit/test_docsite_search.py
+++ b/services/search_docsite/tests/unit/test_docsite_search.py
@@ -138,3 +138,18 @@ def test_get_most_recent_namespace_raises_when_none_valid():
         with pytest.raises(ApolloError) as exc:
             ds._get_most_recent_namespace()
     assert exc.value.code == 404
+
+
+# --- lazy embeddings construction ----------------------------------------------
+
+def test_default_embeddings_built_on_construction_not_import():
+    """`OpenAIEmbeddings()` validates credentials when constructed, so it must not
+    be a default argument — defaults are evaluated at import, which made merely
+    importing this module require OPENAI_API_KEY. Patching only takes effect if
+    the call happens in __init__, so a zero call count means it went back to
+    being a default arg."""
+    with patch.object(m, "OpenAIEmbeddings") as mock_embeddings, \
+         patch.object(m, "PineconeVectorStore", return_value=MagicMock()):
+        m.DocsiteSearch(collection_name="docsite-20240101")
+
+    mock_embeddings.assert_called_once_with()


### PR DESCRIPTION
## Short Description

Create `DocsiteSearch`'s default OpenAI embeddings client lazily so importing the module no longer crashes local setups that have no `OPENAI_API_KEY`.

## Implementation Details

`DocsiteSearch.__init__` used `embeddings=OpenAIEmbeddings()` as a default argument. Default arguments are evaluated at import time, and `OpenAIEmbeddings()` raises without `OPENAI_API_KEY` — and global chat imports this module through its tool definitions, so every global chat request crashed locally even when docsite search was never used.

The default is now constructed inside `__init__` (`embeddings=None` → create when needed). Behavior for real searches is unchanged; importing the module is side-effect free.

Verified: importing `search_docsite` without `OPENAI_API_KEY` succeeds on this branch and raises `openai.OpenAIError` on main. Existing `search_docsite` tests pass (9/9). Changeset included.

Found while testing OpenFn/lightning#4969 against Apollo locally.

## AI Usage

Please disclose whether you've used AI in this work (it's cool, we just want to
know!):

- [x] Yes, I have used AI (Claude Code)
- [ ] No, I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
