### PR TITLE
Planner prompt change: cross-step data contracts

### DIFF
--- a/.changeset/quiet-pans-relax.md
+++ b/.changeset/quiet-pans-relax.md
@@ -1,0 +1,5 @@
+---
+"apollo": minor
+---
+
+Improve planner prompt for coherence

--- a/services/global_chat/prompts.yaml
+++ b/services/global_chat/prompts.yaml
@@ -1,4 +1,4 @@
-prompts_version: 1.0.0
+prompts_version: 1.1.0
 prompts:
   router_system_prompt: |
     You are a routing agent for OpenFn. Route requests to the right handler.
@@ -110,18 +110,19 @@ prompts:
     1. Create/modify workflow structure FIRST (`call_workflow_agent`)
     2. When you're building something new — a whole workflow, or a new step you're also
        writing the code for — define the contract for each edge where one step passes data
-       to another, in system-agnostic terms:
-       - Label—one name for the passed data; give both the producing and consuming step
-         the same name.
+       to another:
+       - Key—one exact state key for the passed data (e.g. `state.patients`): a short
+         camelCase noun; never `data`, `references`, or `configuration` (adaptors
+         overwrite those). Both steps use that exact key.
        - Ownership—one step produces/transforms it; downstream steps consume it as-is and
          never re-derive it.
 
-       Put the identical contract line in both `call_job_code_agent` messages. Describe what
-       flows and which step owns it—never the mechanism (state, return shape, JSONPath,
-       loops, adaptor functions); the job-code agent owns that.
+       Put the identical contract line in both `call_job_code_agent` messages. Name only
+       the key and the owner—how it's produced (return shape, JSONPath, loops, adaptor
+       functions) is the job-code agent's call.
 
-       e.g. "Step A produces the fetched records; Step B consumes them as-is—don't re-fetch
-       or rebuild them."
+       e.g. "Step A writes the fetched records to `state.records`; Step B reads
+       `state.records` as-is—don't re-fetch or rebuild them."
 
        This only applies to work you are creating. When editing existing steps, make only
        the change the user asked for—don't restate contracts, re-derive the data flow, or

--- a/services/global_chat/prompts.yaml
+++ b/services/global_chat/prompts.yaml
@@ -1,4 +1,4 @@
-prompts_version: 1.2.0
+prompts_version: 1.3.0
 prompts:
   router_system_prompt: |
     You are a routing agent for OpenFn. Route requests to the right handler.
@@ -145,8 +145,11 @@ prompts:
       The workflow agent is the expert on which adaptor fits — never name an adaptor yourself.
 
     For each `call_job_code_agent` call:
-    - Set `message` to describe the goal in plain language (e.g. "fetch patient cases from CommCare").
-      The job code agent is the expert — avoid suggesting specific function names unless relevant.
+    - Set `message` to state requirements and constraints: what the step must do, what it must
+      never do, and what data it reads/writes per the contract — never what the code should look
+      like (structure, layout, function choices); the job code agent owns all code decisions.
+      Anything the user explicitly specified (functions, options, field mappings) is a
+      requirement — relay it verbatim.
       Include relevant code only if you used `inspect_job_code` to read existing code.
 
     ### Artifacts

--- a/services/global_chat/prompts.yaml
+++ b/services/global_chat/prompts.yaml
@@ -1,4 +1,4 @@
-prompts_version: 1.1.0
+prompts_version: 1.2.0
 prompts:
   router_system_prompt: |
     You are a routing agent for OpenFn. Route requests to the right handler.
@@ -114,15 +114,21 @@ prompts:
        - Key—one exact state key for the passed data (e.g. `state.patients`): a short
          camelCase noun; never `data`, `references`, or `configuration` (adaptors
          overwrite those). Both steps use that exact key.
+       - Fields—the exact field names inside it: taken from the user's message when
+         given, otherwise choose sensible camelCase names. Every step uses these exact
+         names. Only the producing step maps real source fields into them (and may mark
+         that mapping as adjustable); consumers translate them into their own target
+         system's format internally.
        - Ownership—one step produces/transforms it; downstream steps consume it as-is and
          never re-derive it.
 
        Put the identical contract line in both `call_job_code_agent` messages. Name only
-       the key and the owner—how it's produced (return shape, JSONPath, loops, adaptor
-       functions) is the job-code agent's call.
+       the key, fields, and owner—how it's produced (return shape, JSONPath, loops,
+       adaptor functions) is the job-code agent's call.
 
-       e.g. "Step A writes the fetched records to `state.records`; Step B reads
-       `state.records` as-is—don't re-fetch or rebuild them."
+       e.g. "Step A writes the validated patient to `state.patient` (fields: givenName,
+       familyName, sex 'M'|'F', dateOfBirth, nationalId); Step B reads `state.patient`
+       as-is—don't re-derive it."
 
        This only applies to work you are creating. When editing existing steps, make only
        the change the user asked for—don't restate contracts, re-derive the data flow, or

--- a/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_vague.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_vague.md
@@ -131,7 +131,7 @@ edges:
 - The trigger is a webhook so the workflow runs per Kobo submission, not a cron poll.
 - Before any write, a step looks the patient up in OpenMRS by some identifying field to check whether they already exist.
 - A patient is created only when the lookup found no match; when a match exists the workflow updates or skips instead. Exactly one of these outcomes applies per submission, whether via mutually exclusive branch edges or conditional logic inside a job.
-- The OpenMRS steps use the openmrs adaptor with real functions and plausible arguments, not invented ones, and each step returns state.
+- The OpenMRS steps use openmrs adaptor operations with plausible arguments rather than hand-rolled raw JavaScript, and each step returns state.
 - Credentials are left to the adaptor configuration, never hardcoded in job code.
 - Do not require validation steps, error handlers or PII-safe logging; the user did not ask for them in this phrasing (they are fine to include).
 

--- a/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_vague.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_vague.md
@@ -1,0 +1,146 @@
+---
+id: global-chat.gold.kobo-openmrs-vague
+service: global_chat
+judges: [general, openfn_workflow_expert, openfn_code_quality]
+---
+
+# notes
+
+Vague phrasing of the Kobo-to-OpenMRS patient registration pattern:
+webhook-triggered form submission, dedup lookup, then create or update in
+OpenMRS. The user gives only two hard requirements, so those two carry the
+test:
+
+- "When a new Kobo form is submitted" pins an event-driven shape: a webhook
+  trigger that runs once per submission (Kobo's REST Service posts each
+  submission). A cron job that polls in batches does not match "when a form is
+  submitted".
+- "Don't create duplicates" is the heart of the task: the workflow must look
+  the patient up in OpenMRS before writing, and only create when no match is
+  found. On a match it should update or skip, not blindly create. The two
+  outcomes must be mutually exclusive, whether that is expressed as branch
+  edges or as in-job conditional logic.
+
+Beyond that, the phrasing is loose, so keep evaluation loose. The broader
+rubric this task comes from also covers field validation, PII-free logging,
+and "no match / multiple match" edge cases; the user asked for none of that
+here, so treat it as a bonus if present and do not penalize its absence. The
+form fields and OpenMRS identifier/location UUIDs are unknown, so sensible
+assumptions and clearly named placeholders are expected and fine. Hardcoded
+credentials would still be a clear issue (credentials belong in the adaptor
+configuration).
+
+The following workflow is a NON-BINDING reference showing one acceptable
+shape. Do not require the candidate to match it: step count, job names,
+adaptor versions, the exact openmrs function signatures, the assumed form
+field names, and whether create-vs-update is done via branch edges or inside
+one job body may all differ. A validation step or an error path is also fine
+even though this reference has none. Use it only to sanity-check that the
+candidate is a plausible, coherent solution.
+
+```yaml
+name: kobo-to-openmrs-registration
+jobs:
+  Prepare-submission:
+    name: Prepare submission
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        console.log(`Processing submission ${state.data?._id ?? '(no id)'}`);
+        return { ...state, submission: state.data };
+      });
+  Lookup-patient:
+    name: Look up patient in OpenMRS
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      get('patient', { q: $.submission.national_id });
+
+      fn((state) => {
+        const matches = state.data?.results ?? [];
+        console.log(`Lookup returned ${matches.length} match(es)`);
+        return { ...state, existingPatient: matches[0] ?? null };
+      });
+  Create-patient:
+    name: Create patient
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      create('patient', (state) => {
+        const s = state.submission;
+        return {
+          identifiers: [
+            {
+              identifierType: state.identifierTypeUuid,
+              identifier: s.national_id,
+              location: state.locationUuid,
+              preferred: true,
+            },
+          ],
+          person: {
+            names: [{ givenName: s.given_name, familyName: s.family_name }],
+            gender: s.sex,
+            birthdate: s.date_of_birth,
+          },
+        };
+      });
+  Update-patient:
+    name: Update existing patient
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      update(`person/${$.existingPatient.uuid}`, (state) => {
+        const s = state.submission;
+        return {
+          names: [{ givenName: s.given_name, familyName: s.family_name }],
+          gender: s.sex,
+          birthdate: s.date_of_birth,
+        };
+      });
+triggers:
+  webhook:
+    type: webhook
+    enabled: true
+edges:
+  webhook->Prepare-submission:
+    condition_type: always
+    enabled: true
+    target_job: Prepare-submission
+    source_trigger: webhook
+  Prepare-submission->Lookup-patient:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Lookup-patient
+    source_job: Prepare-submission
+  Lookup-patient->Create-patient:
+    condition_type: js_expression
+    condition_label: patient not found
+    condition_expression: "!state.existingPatient"
+    enabled: true
+    target_job: Create-patient
+    source_job: Lookup-patient
+  Lookup-patient->Update-patient:
+    condition_type: js_expression
+    condition_label: patient exists
+    condition_expression: "state.existingPatient"
+    enabled: true
+    target_job: Update-patient
+    source_job: Lookup-patient
+```
+
+# quality_criteria
+
+- A complete workflow is produced (assumptions and placeholder UUIDs or field names are fine), rather than only clarifying questions.
+- The trigger is a webhook so the workflow runs per Kobo submission, not a cron poll.
+- Before any write, a step looks the patient up in OpenMRS by some identifying field to check whether they already exist.
+- A patient is created only when the lookup found no match; when a match exists the workflow updates or skips instead. Exactly one of these outcomes applies per submission, whether via mutually exclusive branch edges or conditional logic inside a job.
+- The OpenMRS steps use the openmrs adaptor with real functions and plausible arguments, not invented ones, and each step returns state.
+- Credentials are left to the adaptor configuration, never hardcoded in job code.
+- Do not require validation steps, error handlers or PII-safe logging; the user did not ask for them in this phrasing (they are fine to include).
+
+# turn
+
+## role
+
+user
+
+## content
+
+When a new Kobo form is submitted, register the patient in OpenMRS. Don't create duplicates.

--- a/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_verbose.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_verbose.md
@@ -153,7 +153,7 @@ edges:
 - Create and update are mutually exclusive paths: create only runs when no match was found, update only when one was. On the create path the national ID is set as a preferred identifier alongside the demographics.
 - The update path modifies demographics only and does not reassign or resend identifiers.
 - Logging is PII-free everywhere, including the error handler: the submission id may be logged, but never names, dates of birth or national IDs.
-- The openmrs adaptor is used for OpenMRS steps and common for validation/logging, with real functions and plausible arguments; identifier type and location UUIDs are placeholders or state/config references, and credentials are never hardcoded.
+- The openmrs adaptor is used for OpenMRS steps and common for validation/logging, with operations called with plausible arguments; identifier type and location UUIDs are placeholders or state/config references, and credentials are never hardcoded.
 
 # turn
 

--- a/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_verbose.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_kobo_to_openmrs_verbose.md
@@ -1,0 +1,174 @@
+---
+id: global-chat.gold.kobo-openmrs-verbose
+service: global_chat
+judges: [general, openfn_workflow_expert, openfn_code_quality]
+---
+
+# notes
+
+Verbose phrasing of the Kobo-to-OpenMRS patient registration pattern:
+webhook-triggered submission, validate, dedup lookup, branch to
+create-vs-update, plus an error path for invalid submissions. This is the
+hardest cluster (branching, dedup, PII) and the user spells all of it out, so
+the response should honor the explicit instructions. The ones that carry the
+test:
+
+- "Do not use the kobotoolbox adaptor to fetch anything, the data is already
+  here" is explicit. The webhook delivers the submission in `state.data`; an
+  added Kobo fetch step is a clear failure (the rubric's "no unnecessary extra
+  steps").
+- Validation must gate the writes: missing required fields (given name,
+  family name, sex 'M'/'F', date of birth, national ID) fail the run so it
+  routes to an error handler, and an invalid submission must never reach the
+  OpenMRS write steps.
+- Dedup and branching: look up by national ID, then create-vs-update as
+  mutually exclusive paths. The update path touches demographics only and does
+  not reassign identifiers, exactly as instructed.
+- PII discipline is explicit here: log only the submission id, never names,
+  dates of birth or national IDs, including in the error handler's message.
+
+The following workflow is a NON-BINDING reference showing one acceptable
+shape. Do not require the candidate to match it: job names, adaptor versions,
+exact openmrs function signatures, how the branch conditions are expressed
+(edge conditions vs in-job logic), and how validation failure is routed may
+all differ. Placeholder UUIDs for identifier type and location are expected
+since the prompt says they are configured separately. Use it only to
+sanity-check that the candidate is a plausible, coherent solution; we want to
+catch clear issues against the explicit instructions above, not enforce this
+exact structure.
+
+```yaml
+name: kobo-to-openmrs-registration
+jobs:
+  Validate-submission:
+    name: Validate submission
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        const s = state.data;
+        const required = ['given_name', 'family_name', 'sex', 'date_of_birth', 'national_id'];
+        const missing = required.filter((f) => !s?.[f]);
+        if (missing.length > 0 || !['M', 'F'].includes(s.sex)) {
+          console.log(`Submission ${s?._id ?? '(no id)'} failed validation`);
+          throw new Error('Invalid submission');
+        }
+        console.log(`Submission ${s._id} validated`);
+        return { ...state, submission: s };
+      });
+  Lookup-patient:
+    name: Look up patient by national ID
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      get('patient', { q: $.submission.national_id });
+
+      fn((state) => {
+        const matches = state.data?.results ?? [];
+        console.log(`Lookup returned ${matches.length} match(es)`);
+        return { ...state, existingPatient: matches[0] ?? null };
+      });
+  Create-patient:
+    name: Create patient
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      create('patient', (state) => {
+        const s = state.submission;
+        return {
+          identifiers: [
+            {
+              identifierType: state.identifierTypeUuid,
+              identifier: s.national_id,
+              location: state.locationUuid,
+              preferred: true,
+            },
+          ],
+          person: {
+            names: [{ givenName: s.given_name, familyName: s.family_name }],
+            gender: s.sex,
+            birthdate: s.date_of_birth,
+          },
+        };
+      });
+  Update-patient:
+    name: Update existing patient demographics
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      update(`person/${$.existingPatient.uuid}`, (state) => {
+        const s = state.submission;
+        return {
+          names: [{ givenName: s.given_name, familyName: s.family_name }],
+          gender: s.sex,
+          birthdate: s.date_of_birth,
+        };
+      });
+  Log-invalid-submission:
+    name: Log invalid submission
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        console.log('Submission rejected by validation; no patient data written');
+        return state;
+      });
+triggers:
+  webhook:
+    type: webhook
+    enabled: true
+edges:
+  webhook->Validate-submission:
+    condition_type: always
+    enabled: true
+    target_job: Validate-submission
+    source_trigger: webhook
+  Validate-submission->Lookup-patient:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Lookup-patient
+    source_job: Validate-submission
+  Validate-submission->Log-invalid-submission:
+    condition_type: on_job_failure
+    enabled: true
+    target_job: Log-invalid-submission
+    source_job: Validate-submission
+  Lookup-patient->Create-patient:
+    condition_type: js_expression
+    condition_label: patient not found
+    condition_expression: "!state.existingPatient"
+    enabled: true
+    target_job: Create-patient
+    source_job: Lookup-patient
+  Lookup-patient->Update-patient:
+    condition_type: js_expression
+    condition_label: patient exists
+    condition_expression: "state.existingPatient"
+    enabled: true
+    target_job: Update-patient
+    source_job: Lookup-patient
+```
+
+# quality_criteria
+
+- The trigger is a webhook and there is no step that fetches data from KoboToolbox; the submission is consumed from `state.data` as the user explicitly instructed.
+- A validation step checks the five required fields (given name, family name, sex as 'M' or 'F', date of birth, national ID) and fails the run when any are missing, so execution routes to an error handler rather than continuing.
+- Invalid submissions never reach an OpenMRS write step: the create/update steps are only reachable after validation succeeds.
+- A step looks the patient up in OpenMRS by national ID before any write.
+- Create and update are mutually exclusive paths: create only runs when no match was found, update only when one was. On the create path the national ID is set as a preferred identifier alongside the demographics.
+- The update path modifies demographics only and does not reassign or resend identifiers.
+- Logging is PII-free everywhere, including the error handler: the submission id may be logged, but never names, dates of birth or national IDs.
+- The openmrs adaptor is used for OpenMRS steps and common for validation/logging, with real functions and plausible arguments; identifier type and location UUIDs are placeholders or state/config references, and credentials are never hardcoded.
+
+# turn
+
+## role
+
+user
+
+## content
+
+Build a workflow that registers patients in OpenMRS from a KoboToolbox registration form.
+Trigger: a webhook. Kobo's REST Service posts one submission at a time as the request body, so the submission is already available in state.data. Do not use the kobotoolbox adaptor to fetch anything, the data is already here.
+Steps:
+Validate the submission. Required fields are given name, family name, sex ('M' or 'F'), date of birth, and national ID. If any are missing, fail the run so it routes to an error handler. Only log the submission id, never the personal fields.
+Look up the patient in OpenMRS by national ID to check whether they already exist.
+If they do not exist, create a new patient with their national ID as a preferred identifier plus their demographics.
+If they already exist, update their demographics only. Do not reassign identifiers.
+If validation failed, send the run to a separate step that logs a PII-free message.
+Use the openmrs adaptor for the OpenMRS steps and common for validation and logging. Assume identifier type and location UUIDs are configured separately. Do not hardcode credentials. Do not log patient names, dates of birth, or national IDs anywhere.

--- a/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_vague.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_vague.md
@@ -146,7 +146,7 @@ edges:
 - The right adaptor is used for each system: openmrs for the OpenMRS save, dhis2 for DHIS2, and fhir for the FHIR server.
 - Before creating in OpenMRS, a step looks the patient up to check for an existing record; create only happens when no match is found, with update or skip otherwise, and exactly one of those outcomes applies per submission.
 - The DHIS2 and FHIR sends run after the OpenMRS save succeeds, matching "then also send them".
-- Job code uses real adaptor functions with plausible arguments, not invented ones, and each step returns state.
+- Job code uses adaptor operations with plausible arguments rather than hand-rolled raw JavaScript, and each step returns state.
 - Credentials are left to the adaptor configuration, never hardcoded in job code.
 - Do not require validation steps, generated identifiers, PII-safe logging or downstream error handlers; the user did not ask for them in this phrasing (they are fine to include).
 

--- a/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_vague.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_vague.md
@@ -1,0 +1,161 @@
+---
+id: global-chat.gold.patient-fanout-vague
+service: global_chat
+judges: [general, openfn_workflow_expert, openfn_code_quality]
+---
+
+# notes
+
+Vague phrasing of the large fan-out pattern: a webhook-delivered patient form
+goes to OpenMRS (deduplicated), then on to DHIS2 and a FHIR server. The user
+gives one sentence, so the test is about whether the assistant gets the
+skeleton right, not the fine detail. What carries the test, given the
+phrasing:
+
+- Right adaptor per system: this is a three-target integration, so openmrs,
+  dhis2 and fhir should each be used for their own system (the rubric's
+  "picked the right adaptor for each system involved"). Substituting generic
+  http calls for a system that has a dedicated adaptor, or using one adaptor
+  for another's system, is the kind of clear issue we want caught.
+- "When a new patient form comes in" pins an event-driven shape: a webhook
+  trigger, not a cron poll.
+- "Without duplicates" requires a lookup in OpenMRS before writing, with
+  create happening only when no match is found (update or skip otherwise).
+- "Then also send them" gives an ordering: the DHIS2 and FHIR sends happen
+  after the OpenMRS save, not before or instead of it.
+
+Everything else in the broader rubric (field validation, generated
+identifiers, PII-free logging, downstream error handlers, exact
+attribute/resource mapping) is not asked for in this phrasing: treat it as a
+bonus if present and do not penalize its absence. Form fields and
+instance-specific UUIDs (identifier types, org units, tracked entity types)
+are unknown, so assumptions and clearly named placeholders are expected.
+Hardcoded credentials would still be a clear issue.
+
+The following workflow is a NON-BINDING reference showing one acceptable
+shape. Do not require the candidate to match it: step count and names, adaptor
+versions, exact function signatures, the assumed form fields, and whether
+create-vs-update is expressed as branch edges or as in-job logic may all
+differ. Use it only to sanity-check that the candidate is a plausible,
+coherent solution.
+
+```yaml
+name: patient-fanout
+jobs:
+  Prepare-submission:
+    name: Prepare submission
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        console.log(`Processing submission ${state.data?._id ?? '(no id)'}`);
+        return { ...state, submission: state.data };
+      });
+  Upsert-patient-in-openmrs:
+    name: Upsert patient in OpenMRS
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      get('patient', { q: $.submission.national_id });
+
+      fn((state) => {
+        const matches = state.data?.results ?? [];
+        console.log(`Lookup returned ${matches.length} match(es)`);
+        return { ...state, existingPatient: matches[0] ?? null };
+      });
+
+      fn((state) => {
+        const s = state.submission;
+        const person = {
+          names: [{ givenName: s.given_name, familyName: s.family_name }],
+          gender: s.sex,
+          birthdate: s.date_of_birth,
+        };
+        if (state.existingPatient) {
+          return update(`person/${state.existingPatient.uuid}`, person)(state);
+        }
+        return create('patient', {
+          identifiers: [
+            {
+              identifierType: state.identifierTypeUuid,
+              identifier: s.national_id,
+              location: state.locationUuid,
+              preferred: true,
+            },
+          ],
+          person,
+        })(state);
+      });
+  Send-to-dhis2:
+    name: Create tracked entity in DHIS2
+    adaptor: "@openfn/language-dhis2@latest"
+    body: |
+      create('trackedEntityInstances', (state) => {
+        const s = state.submission;
+        return {
+          trackedEntityType: state.trackedEntityTypeId,
+          orgUnit: state.orgUnitId,
+          attributes: [
+            { attribute: state.givenNameAttributeId, value: s.given_name },
+            { attribute: state.familyNameAttributeId, value: s.family_name },
+          ],
+        };
+      });
+  Send-to-fhir:
+    name: Post Patient resource to FHIR
+    adaptor: "@openfn/language-fhir@latest"
+    body: |
+      create('Patient', (state) => {
+        const s = state.submission;
+        return {
+          resourceType: 'Patient',
+          name: [{ given: [s.given_name], family: s.family_name }],
+          gender: s.sex === 'M' ? 'male' : 'female',
+          birthDate: s.date_of_birth,
+        };
+      });
+triggers:
+  webhook:
+    type: webhook
+    enabled: true
+edges:
+  webhook->Prepare-submission:
+    condition_type: always
+    enabled: true
+    target_job: Prepare-submission
+    source_trigger: webhook
+  Prepare-submission->Upsert-patient-in-openmrs:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Upsert-patient-in-openmrs
+    source_job: Prepare-submission
+  Upsert-patient-in-openmrs->Send-to-dhis2:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Send-to-dhis2
+    source_job: Upsert-patient-in-openmrs
+  Send-to-dhis2->Send-to-fhir:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Send-to-fhir
+    source_job: Send-to-dhis2
+```
+
+# quality_criteria
+
+- A complete workflow is produced (assumptions and placeholder UUIDs or field names are fine), rather than only clarifying questions.
+- The trigger is a webhook so the workflow runs per incoming patient form, not a cron poll.
+- The right adaptor is used for each system: openmrs for the OpenMRS save, dhis2 for DHIS2, and fhir for the FHIR server.
+- Before creating in OpenMRS, a step looks the patient up to check for an existing record; create only happens when no match is found, with update or skip otherwise, and exactly one of those outcomes applies per submission.
+- The DHIS2 and FHIR sends run after the OpenMRS save succeeds, matching "then also send them".
+- Job code uses real adaptor functions with plausible arguments, not invented ones, and each step returns state.
+- Credentials are left to the adaptor configuration, never hardcoded in job code.
+- Do not require validation steps, generated identifiers, PII-safe logging or downstream error handlers; the user did not ask for them in this phrasing (they are fine to include).
+
+# turn
+
+## role
+
+user
+
+## content
+
+When a new patient form comes in, save the patient to OpenMRS without duplicates, then also send them to DHIS2 and a FHIR server.

--- a/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_verbose.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_verbose.md
@@ -1,0 +1,230 @@
+---
+id: global-chat.gold.patient-fanout-verbose
+service: global_chat
+judges: [general, openfn_workflow_expert, openfn_code_quality]
+---
+
+# notes
+
+Verbose phrasing of the large fan-out pattern: a webhook-delivered
+registration event is validated, deduplicated against OpenMRS, created or
+updated there (with a generated identifier on the create path), then fanned
+out to DHIS2 and a FHIR server, with error paths for invalid input and
+downstream failures. The user spells everything out, so the response should
+honor the explicit instructions. The ones that carry the test:
+
+- "Do not add a fetch step" is explicit: the event arrives in `state.data`
+  via webhook, so an added fetch from the source system is a clear failure.
+- The idgen requirement is called out hard in the prompt: the OpenMRS ID has a
+  check digit and "must be generated, not made up". Code that fabricates an ID
+  (random string, timestamp, national ID reused as the OpenMRS ID) instead of
+  requesting one from the idgen source is a clear failure. On the create path
+  the generated ID is the preferred identifier and the national ID is a
+  second, non-preferred identifier.
+- Validation gates the writes: missing required fields (given name, family
+  name, sex 'M'/'F', date of birth, national ID) fail the run to an
+  invalid-input handler, and invalid events must never reach any write step.
+- Ordering and convergence: DHIS2 and FHIR run only after the OpenMRS write
+  succeeded, on either the create or the update path. Cross-standard mapping
+  matters at the FHIR step: sex 'M'/'F' maps to gender 'male'/'female'.
+- PII discipline is explicit: only the submission id is ever logged, never
+  names, dates of birth or national IDs, including in both error handlers.
+
+Because OpenFn workflows are trees (a step has one parent), candidates may
+express create-vs-update as in-job conditional logic on a single path, or as
+branch edges with the downstream fan-out duplicated under each branch. Either
+is acceptable as long as the paths are mutually exclusive and the fan-out runs
+after either one. Similarly the downstream-error handling may be one handler
+per failing step or any equivalent arrangement.
+
+The following workflow is a NON-BINDING reference showing one acceptable
+shape. Do not require the candidate to match it: job names, adaptor versions,
+exact function signatures (especially the idgen call and the DHIS2/FHIR
+payload details), and how branches and error routes are wired may all differ.
+Placeholder UUIDs are expected since the prompt says identifier type,
+location, org unit, program and attribute UUIDs are configured separately. Use
+it only to sanity-check that the candidate is a plausible, coherent solution;
+we want to catch clear issues against the explicit instructions above, not
+enforce this exact structure. Pagination and idempotency concerns from the
+broader rubric are not relevant to this single-event pattern.
+
+```yaml
+name: patient-registration-fanout
+jobs:
+  Validate-event:
+    name: Validate registration event
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        const s = state.data;
+        const required = ['given_name', 'family_name', 'sex', 'date_of_birth', 'national_id'];
+        const missing = required.filter((f) => !s?.[f]);
+        if (missing.length > 0 || !['M', 'F'].includes(s.sex)) {
+          console.log(`Submission ${s?._id ?? '(no id)'} failed validation`);
+          throw new Error('Invalid registration event');
+        }
+        console.log(`Submission ${s._id} validated`);
+        return { ...state, submission: s };
+      });
+  Upsert-patient-in-openmrs:
+    name: Upsert patient in OpenMRS
+    adaptor: "@openfn/language-openmrs@latest"
+    body: |
+      get('patient', { q: $.submission.national_id });
+
+      fn((state) => {
+        const matches = state.data?.results ?? [];
+        console.log(`Lookup returned ${matches.length} match(es)`);
+        return { ...state, existingPatient: matches[0] ?? null };
+      });
+
+      fn((state) => {
+        const s = state.submission;
+        const person = {
+          names: [{ givenName: s.given_name, familyName: s.family_name }],
+          gender: s.sex,
+          birthdate: s.date_of_birth,
+        };
+        if (state.existingPatient) {
+          return update(`person/${state.existingPatient.uuid}`, person)(state);
+        }
+        return post(
+          `idgen/identifiersource/${state.idgenSourceUuid}/identifier`,
+          { comment: 'OpenFn registration' }
+        )(state).then((next) => {
+          const generatedId = next.data?.identifier;
+          return create('patient', {
+            identifiers: [
+              {
+                identifierType: next.openmrsIdTypeUuid,
+                identifier: generatedId,
+                location: next.locationUuid,
+                preferred: true,
+              },
+              {
+                identifierType: next.nationalIdTypeUuid,
+                identifier: next.submission.national_id,
+                preferred: false,
+              },
+            ],
+            person,
+          })(next);
+        });
+      });
+  Send-to-dhis2:
+    name: Create tracked entity in DHIS2
+    adaptor: "@openfn/language-dhis2@latest"
+    body: |
+      create('trackedEntityInstances', (state) => {
+        const s = state.submission;
+        return {
+          trackedEntityType: state.trackedEntityTypeId,
+          orgUnit: state.orgUnitId,
+          attributes: [
+            { attribute: state.givenNameAttributeId, value: s.given_name },
+            { attribute: state.familyNameAttributeId, value: s.family_name },
+          ],
+        };
+      });
+  Send-to-fhir:
+    name: Post Patient resource to FHIR
+    adaptor: "@openfn/language-fhir@latest"
+    body: |
+      create('Patient', (state) => {
+        const s = state.submission;
+        return {
+          resourceType: 'Patient',
+          name: [{ given: [s.given_name], family: s.family_name }],
+          gender: s.sex === 'M' ? 'male' : 'female',
+          birthDate: s.date_of_birth,
+        };
+      });
+  Log-invalid-input:
+    name: Log invalid input
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        console.log('Event rejected by validation; no data written');
+        return state;
+      });
+  Log-dhis2-failure:
+    name: Log DHIS2 sync failure
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        console.log('DHIS2 write failed after OpenMRS registration; flag for retry');
+        return state;
+      });
+  Log-fhir-failure:
+    name: Log FHIR sync failure
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn((state) => {
+        console.log('FHIR write failed after OpenMRS registration; flag for retry');
+        return state;
+      });
+triggers:
+  webhook:
+    type: webhook
+    enabled: true
+edges:
+  webhook->Validate-event:
+    condition_type: always
+    enabled: true
+    target_job: Validate-event
+    source_trigger: webhook
+  Validate-event->Upsert-patient-in-openmrs:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Upsert-patient-in-openmrs
+    source_job: Validate-event
+  Validate-event->Log-invalid-input:
+    condition_type: on_job_failure
+    enabled: true
+    target_job: Log-invalid-input
+    source_job: Validate-event
+  Upsert-patient-in-openmrs->Send-to-dhis2:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Send-to-dhis2
+    source_job: Upsert-patient-in-openmrs
+  Send-to-dhis2->Send-to-fhir:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Send-to-fhir
+    source_job: Send-to-dhis2
+  Send-to-dhis2->Log-dhis2-failure:
+    condition_type: on_job_failure
+    enabled: true
+    target_job: Log-dhis2-failure
+    source_job: Send-to-dhis2
+  Send-to-fhir->Log-fhir-failure:
+    condition_type: on_job_failure
+    enabled: true
+    target_job: Log-fhir-failure
+    source_job: Send-to-fhir
+```
+
+# quality_criteria
+
+- The trigger is a webhook and there is no added fetch step; the registration event is consumed from `state.data` as the user explicitly instructed.
+- A validation step checks the five required fields (given name, family name, sex as 'M' or 'F', date of birth, national ID) and fails the run to an invalid-input handler when any are missing; invalid events never reach any write step.
+- A step looks the patient up in OpenMRS by national ID before any write, and the create and update outcomes are mutually exclusive (via branch edges or in-job logic).
+- On the create path, the OpenMRS ID is obtained from the idgen source rather than fabricated in code, and it becomes the preferred identifier with the national ID as a second, non-preferred identifier.
+- On the update path, only demographics are modified and identifiers are not resent.
+- After the OpenMRS write succeeds on either path, a DHIS2 tracked entity instance is created (name attributes, org unit, tracked entity type) and then a FHIR Patient resource is POSTed, with the sex code mapped to the FHIR gender value set (M to male, F to female).
+- A DHIS2 or FHIR failure routes to downstream-error handling that logs a PII-free message; the workflow does not silently succeed past a failed write.
+- The named adaptors are used for their systems (common, openmrs, dhis2, fhir) with real functions; instance-specific UUIDs appear as placeholders or state/config references, credentials are never hardcoded, and no names, dates of birth or national IDs appear in any log.
+
+# turn
+
+## role
+
+user
+
+## content
+
+Build an event-driven workflow that registers a patient across three systems.
+Trigger: a webhook. KoboToolbox posts one registration event as the request body via its REST Service, so the data is already in state.data. Do not add a fetch step.
+Steps: Validate the event. Required fields are given name, family name, sex ('M' or 'F'), date of birth, and national ID. If any are missing, fail the run so it routes to an invalid-input handler. Only log the submission id, never the personal fields. Look up the patient in OpenMRS by national ID to check whether they already exist. If they do not exist: generate a valid OpenMRS ID from the idgen source (it is required and has a check digit, so it must be generated, not made up), then create the patient with the generated OpenMRS ID as the preferred identifier and the national ID as a second, non-preferred identifier that has no check-digit rule. If they already exist: update their demographics only. Do not resend identifiers. After the OpenMRS write succeeds (either path), create a DHIS2 tracked entity instance for the patient with their name attributes, org unit, and tracked entity type. Then convert the patient to a FHIR Patient resource and POST it to the FHIR server. Map the sex code to the FHIR gender value set (M to male, F to female). If either the DHIS2 or FHIR write fails, route to a downstream-error handler that logs a PII-free message for retry.
+Use common for validation and logging, openmrs for the OpenMRS steps, dhis2 for the tracked entity, and fhir for the FHIR resource. Do not hardcode credentials. Do not log names, dates of birth, or national IDs anywhere. Identifier type, location, org unit, program, and attribute UUIDs are instance-specific and configured separately.

--- a/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_verbose.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_patient_fanout_verbose.md
@@ -214,7 +214,7 @@ edges:
 - On the update path, only demographics are modified and identifiers are not resent.
 - After the OpenMRS write succeeds on either path, a DHIS2 tracked entity instance is created (name attributes, org unit, tracked entity type) and then a FHIR Patient resource is POSTed, with the sex code mapped to the FHIR gender value set (M to male, F to female).
 - A DHIS2 or FHIR failure routes to downstream-error handling that logs a PII-free message; the workflow does not silently succeed past a failed write.
-- The named adaptors are used for their systems (common, openmrs, dhis2, fhir) with real functions; instance-specific UUIDs appear as placeholders or state/config references, credentials are never hardcoded, and no names, dates of birth or national IDs appear in any log.
+- The named adaptors are used for their systems (common, openmrs, dhis2, fhir); instance-specific UUIDs appear as placeholders or state/config references, credentials are never hardcoded, and no names, dates of birth or national IDs appear in any log.
 
 # turn
 

--- a/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_vague.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_vague.md
@@ -1,0 +1,100 @@
+---
+id: global-chat.gold.rest-to-rest-vague
+service: global_chat
+judges: [general, openfn_workflow_expert, openfn_code_quality]
+---
+
+# notes
+
+Vague phrasing of the REST-to-REST baseline: the simplest end-to-end pattern
+(cron-triggered fetch, transform, post) between two unauthenticated
+JSONPlaceholder endpoints. The user names both endpoints and a daily cadence
+but nothing else, so despite the loose wording the request is fully actionable
+and a complete workflow should come back, not just clarifying questions.
+
+What matters most given how the task is phrased:
+
+- "Every morning" pins the trigger: a daily cron schedule, not a webhook.
+- "Simplify each one" is deliberately underspecified. Any reasonable smaller
+  projection of the user objects is acceptable; do not require particular
+  field names.
+- Both systems are plain REST, so the http adaptor with real functions (get,
+  post, fn, each) is the expected shape, not invented helpers.
+
+The broader rubric this task comes from also covers deduplication,
+idempotency, pagination, validation and PII handling. None of those are asked
+for here and the pattern does not need them, so do not penalize their absence.
+We only want to catch clear issues: wrong trigger, wrong adaptor, invented
+functions, broken data flow between steps, or invented complexity the user
+never asked for.
+
+The following workflow is a NON-BINDING reference showing one acceptable
+shape. Do not require the candidate to match it: step count (fetch and
+transform may be one step or two), job names, adaptor versions, the chosen
+"simplified" fields and the state key used between steps may all differ. Use
+it only to sanity-check that the candidate is a plausible, coherent solution.
+
+```yaml
+name: daily-users-sync
+jobs:
+  Fetch-and-transform-users:
+    name: Fetch and transform users
+    adaptor: "@openfn/language-http@latest"
+    body: |
+      get('https://jsonplaceholder.typicode.com/users');
+
+      fn((state) => {
+        const records = (state.data || []).map((user) => ({
+          userId: user.id,
+          name: user.name,
+          email: user.email,
+        }));
+        console.log(`Transformed ${records.length} users`);
+        return { ...state, records };
+      });
+  Post-records:
+    name: Post records to target
+    adaptor: "@openfn/language-http@latest"
+    body: |
+      each(
+        '$.records[*]',
+        post('https://jsonplaceholder.typicode.com/posts', (state) => state.data)
+      );
+triggers:
+  cron:
+    type: cron
+    enabled: true
+    cron_expression: 0 6 * * *
+edges:
+  cron->Fetch-and-transform-users:
+    condition_type: always
+    enabled: true
+    target_job: Fetch-and-transform-users
+    source_trigger: cron
+  Fetch-and-transform-users->Post-records:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Post-records
+    source_job: Fetch-and-transform-users
+```
+
+# quality_criteria
+
+- A complete workflow is produced (assumptions or placeholders are fine), rather than only clarifying questions, since the request names both endpoints and a schedule.
+- The trigger is a daily cron (a morning schedule such as `0 6 * * *`, or any once-a-day expression), not a webhook.
+- A step fetches the user list from `https://jsonplaceholder.typicode.com/users` with an HTTP get.
+- Each user is reduced to some smaller object. Any sensible choice of fields is fine; do not require specific field names since the user only said "simplify".
+- Each transformed record is POSTed to `https://jsonplaceholder.typicode.com/posts`.
+- Job code uses real http adaptor functions with plausible arguments, not invented helpers, and each step returns state.
+- The posting step consumes what the transform produced under a consistent state key, rather than re-fetching or rebuilding the data.
+- No invented requirements: no authentication, deduplication or branching the user did not ask for.
+
+# turn
+
+## role
+
+user
+
+## content
+
+Every morning, get the list of users from https://jsonplaceholder.typicode.com/users, simplify each one, and post them to https://jsonplaceholder.typicode.com/posts.

--- a/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_vague.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_vague.md
@@ -85,7 +85,7 @@ edges:
 - A step fetches the user list from `https://jsonplaceholder.typicode.com/users` with an HTTP get.
 - Each user is reduced to some smaller object. Any sensible choice of fields is fine; do not require specific field names since the user only said "simplify".
 - Each transformed record is POSTed to `https://jsonplaceholder.typicode.com/posts`.
-- Job code uses real http adaptor functions with plausible arguments, not invented helpers, and each step returns state.
+- Job code uses http adaptor operations with plausible arguments rather than hand-rolled raw JavaScript, and each step returns state.
 - The posting step consumes what the transform produced under a consistent state key, rather than re-fetching or rebuilding the data.
 - No invented requirements: no authentication, deduplication or branching the user did not ask for.
 

--- a/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_verbose.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_verbose.md
@@ -88,7 +88,7 @@ edges:
 - A step fetches the user list from `https://jsonplaceholder.typicode.com/users` with an HTTP get.
 - A transform maps each user to exactly the three requested fields: `userId` (the user's id), `title` (the user's name) and `body` (a string combining the user's email and company name).
 - Each transformed record is POSTed to `https://jsonplaceholder.typicode.com/posts`.
-- Job code uses real http adaptor functions with plausible arguments, not invented helpers, and each step returns state.
+- Job code uses http adaptor operations with plausible arguments rather than hand-rolled raw JavaScript, and each step returns state.
 - Data-flow coherence: the posting step consumes the transform's output under the same state key it was written to, without re-fetching users or rebuilding the transformed objects.
 - The solution stays simple as instructed: no branching, deduplication or auth logic beyond what was asked.
 

--- a/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_verbose.md
+++ b/services/global_chat/tests/acceptance/gold_workflows/test_rest_to_rest_daily_verbose.md
@@ -1,0 +1,106 @@
+---
+id: global-chat.gold.rest-to-rest-verbose
+service: global_chat
+judges: [general, openfn_workflow_expert, openfn_code_quality]
+---
+
+# notes
+
+Verbose phrasing of the REST-to-REST baseline: the simplest end-to-end pattern
+(cron-triggered fetch, transform, post) between two unauthenticated
+JSONPlaceholder endpoints. Unlike the vague variant, the user spells out the
+trigger cadence, the exact three-field target shape, the adaptor to use, and
+explicitly asks to keep it simple.
+
+What matters most given how the task is phrased:
+
+- The spec is precise, so the output should honor it precisely: a once-a-day
+  cron, the http adaptor as named, and a transform to exactly `userId` (the
+  user's id), `title` (the user's name) and `body` (a string combining email
+  and company name).
+- Data-flow coherence across steps: the transform and the post step must agree
+  on how transformed records pass between them. The downstream step consumes
+  exactly what the upstream step produced, under the same state key, without
+  re-fetching or rebuilding it.
+- "Keep it simple: no branching or deduplication" is an explicit instruction,
+  so added branching, dedup or auth logic counts against the response here.
+
+The broader rubric this task comes from also covers idempotency, pagination,
+validation and PII handling. The user explicitly ruled that kind of thing out,
+so do not penalize its absence. We only want to catch clear issues: wrong
+trigger, wrong adaptor, wrong field mapping, invented functions, or broken
+data flow between steps.
+
+The following workflow is a NON-BINDING reference showing one acceptable
+shape. Do not require the candidate to match it: step count (fetch and
+transform may be one step or two), job names, adaptor versions, the exact
+`body` string format and the state key used between steps may all differ. Use
+it only to sanity-check that the candidate is a plausible, coherent solution.
+
+```yaml
+name: daily-rest-to-rest-sync
+jobs:
+  Fetch-and-transform-users:
+    name: Fetch and transform users
+    adaptor: "@openfn/language-http@latest"
+    body: |
+      get('https://jsonplaceholder.typicode.com/users');
+
+      fn((state) => {
+        const records = (state.data || []).map((user) => ({
+          userId: user.id,
+          title: user.name,
+          body: `${user.email} | ${user.company?.name ?? ''}`,
+        }));
+        console.log(`Transformed ${records.length} users`);
+        return { ...state, records };
+      });
+  Post-records:
+    name: Post records to target
+    adaptor: "@openfn/language-http@latest"
+    body: |
+      each(
+        '$.records[*]',
+        post('https://jsonplaceholder.typicode.com/posts', (state) => state.data)
+      );
+triggers:
+  cron:
+    type: cron
+    enabled: true
+    cron_expression: 0 0 * * *
+edges:
+  cron->Fetch-and-transform-users:
+    condition_type: always
+    enabled: true
+    target_job: Fetch-and-transform-users
+    source_trigger: cron
+  Fetch-and-transform-users->Post-records:
+    condition_type: on_job_success
+    enabled: true
+    target_job: Post-records
+    source_job: Fetch-and-transform-users
+```
+
+# quality_criteria
+
+- The trigger is a cron scheduled once a day (e.g. `0 0 * * *` or similar), not a webhook or a different frequency.
+- The http adaptor is used, as the user explicitly requested.
+- A step fetches the user list from `https://jsonplaceholder.typicode.com/users` with an HTTP get.
+- A transform maps each user to exactly the three requested fields: `userId` (the user's id), `title` (the user's name) and `body` (a string combining the user's email and company name).
+- Each transformed record is POSTed to `https://jsonplaceholder.typicode.com/posts`.
+- Job code uses real http adaptor functions with plausible arguments, not invented helpers, and each step returns state.
+- Data-flow coherence: the posting step consumes the transform's output under the same state key it was written to, without re-fetching users or rebuilding the transformed objects.
+- The solution stays simple as instructed: no branching, deduplication or auth logic beyond what was asked.
+
+# turn
+
+## role
+
+user
+
+## content
+
+Build a scheduled workflow that copies records between two REST endpoints.
+Trigger: cron, once a day.
+Steps: GET the list of users from https://jsonplaceholder.typicode.com/users Transform each user into a smaller object with three fields: userId (the user's id), title (the user's name), and body (a short string combining their email and company name). POST each transformed record to https://jsonplaceholder.typicode.com/posts
+Use the http adaptor. No authentication is required for this API. Keep it simple: no branching or deduplication.

--- a/services/testing/judge.py
+++ b/services/testing/judge.py
@@ -298,7 +298,7 @@ def evaluate(
 
     response = client.messages.create(
         model=model,
-        max_tokens=4096,
+        max_tokens=16384,
         system=system_prompt,
         messages=[
             {"role": "user", "content": user_prompt},

--- a/services/testing/judge.py
+++ b/services/testing/judge.py
@@ -32,11 +32,10 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
+import yaml
 from anthropic import Anthropic
-
 from models import CLAUDE_SONNET
 from testing.judges import load_judge
-
 
 DEFAULT_MODEL = CLAUDE_SONNET
 DEFAULT_JUDGE = "general"
@@ -97,11 +96,69 @@ def _build_system_prompt(judge_name: str) -> str:
     return "\n".join(parts)
 
 
+_ADAPTOR_DOCS_CAP = 40_000
+_COMMON_ADAPTOR = "@openfn/language-common@latest"
+
+
+def build_adaptor_docs(workflow_yaml: Optional[str]) -> Optional[str]:
+    """Signature listing for the adaptors used in a candidate workflow YAML.
+
+    Grounds judge claims about which adaptor functions exist, instead of the
+    judge guessing from memory. Always includes @openfn/language-common, whose
+    helpers every adaptor re-exports — without it the judge would false-flag
+    `fn`/`each`/etc. on adaptor-specific jobs. Fails open: on any error (no
+    YAML, no DB, no docs) returns None and the judges fall back to their
+    no-docs humility rules.
+    """
+    if not workflow_yaml:
+        return None
+    try:
+        doc = yaml.safe_load(workflow_yaml)
+        jobs = (doc or {}).get("jobs") or {}
+        adaptors = {
+            job["adaptor"]
+            for job in jobs.values()
+            if isinstance(job, dict) and job.get("adaptor")
+        }
+        if not adaptors:
+            return None
+        adaptors.add(_COMMON_ADAPTOR)
+
+        from search_adaptor_docs.search_adaptor_docs import fetch_signatures
+        from util import AdaptorSpecifier, get_db_connection
+
+        sections = []
+        conn = get_db_connection()
+        try:
+            for adaptor in sorted(adaptors):
+                try:
+                    signatures = fetch_signatures(
+                        AdaptorSpecifier(adaptor), conn, auto_load=True
+                    )
+                except Exception:
+                    continue
+                if signatures:
+                    lines = "\n".join(signatures.values())
+                    sections.append(f"<adaptor {adaptor}>\n{lines}\n</adaptor>")
+        finally:
+            conn.close()
+
+        if not sections:
+            return None
+        block = "\n".join(sections)
+        if len(block) > _ADAPTOR_DOCS_CAP:
+            block = block[:_ADAPTOR_DOCS_CAP] + "\n(...truncated)"
+        return block
+    except Exception:
+        return None
+
+
 def _build_user_prompt(
     criteria: list[str],
     candidate: dict,
     test_notes: Optional[str],
     request: Optional[dict],
+    adaptor_docs: Optional[str] = None,
 ) -> str:
     parts = []
     if test_notes:
@@ -114,6 +171,22 @@ def _build_user_prompt(
         parts += [
             "ORIGINAL REQUEST sent to the service (use as ground truth for what existed before and what was asked):",
             json.dumps(request, indent=2, default=str),
+            "",
+        ]
+    if adaptor_docs:
+        parts += [
+            "ADAPTOR DOCUMENTATION (documented functions for the adaptors used in the "
+            "candidate workflow; @openfn/language-common helpers are re-exported by "
+            "every adaptor):",
+            adaptor_docs,
+            "",
+            "Use this to ground claims about whether a function exists and what its "
+            "signature is. The listing can still be incomplete (version drift, "
+            "undocumented helpers), so if a function is absent but you are not "
+            "confident it is invented, or your doubt is about runtime behaviour the "
+            "signatures don't show, do not flag it. An adaptor used in the workflow "
+            "but missing from this listing had no docs available in this run — treat "
+            "its functions as unverifiable, never as nonexistent.",
             "",
         ]
     parts += ["CRITERIA TO EVALUATE:"]
@@ -260,6 +333,7 @@ def evaluate(
     candidate: dict,
     test_notes: Optional[str] = None,
     request: Optional[dict] = None,
+    adaptor_docs: Optional[str] = None,
     judge: str = DEFAULT_JUDGE,
     model: str = DEFAULT_MODEL,
     client: Optional[Anthropic] = None,
@@ -275,6 +349,8 @@ def evaluate(
             provided, the judge can ground "before vs after" reasoning in the
             actual inputs (workflow_yaml, current turn, history) instead of
             guessing.
+        adaptor_docs: Optional adaptor function signatures (from
+            build_adaptor_docs) grounding claims about which functions exist.
         judge: Name of the judge (file at services/testing/judges/<name>.md).
             Defaults to "general".
         model: Model to use. Defaults to CLAUDE_SONNET from services/models.py.
@@ -294,7 +370,7 @@ def evaluate(
         client = Anthropic(api_key=api_key)
 
     system_prompt = _build_system_prompt(judge)
-    user_prompt = _build_user_prompt(criteria, candidate, test_notes, request)
+    user_prompt = _build_user_prompt(criteria, candidate, test_notes, request, adaptor_docs)
 
     response = client.messages.create(
         model=model,

--- a/services/testing/judges/general.md
+++ b/services/testing/judges/general.md
@@ -11,4 +11,5 @@ You will be given (a) optional universal rules that apply to every response, (b)
 - Job names and edge source/target/key references in a returned workflow YAML use only letters, numbers, spaces, hyphens, and underscores.
 - When the user is editing an existing workflow, every job and edge from the existing YAML is present and unchanged in the response unless the user asked to remove or modify it. Additions are fine.
 - Any returned YAML parses as valid YAML.
+- Never claim an adaptor function or signature doesn't exist or is wrong unless adaptor documentation provided in this evaluation contradicts it — you do not have reliable knowledge of adaptor APIs.
 - If a criterion expects a specific concrete output (e.g. a workflow with particular jobs, code using specific functions) but the model instead asks the user a reasonable clarifying question to disambiguate the request, treat the criterion as satisfied. Asking for more information is a valid behaviour. Exception: when the test notes or a criterion explicitly evaluate the model's decision about when to act versus when to ask, grade strictly.

--- a/services/testing/judges/openfn_code_quality.md
+++ b/services/testing/judges/openfn_code_quality.md
@@ -86,7 +86,7 @@ Returning a trimmed object is fine **only as the final cleanup step**, where dro
 ## Adaptor usage
 
 - Use the adaptor operations available in the named adaptor — `each`, `fn`, `fields`, `field`, `dataValue`, `lastReferenceValue`, `combine`, `cursor`, plus the adaptor-specific ones (`get`/`post`/`upsert`/`create`/`bulk`/etc.) — in preference to raw JS loops or hand-rolled HTTP calls, when an equivalent operation exists.
-- Do not invent adaptor functions. If the assistant calls a function that isn't part of the declared adaptor (and isn't a documented `language-common` helper), flag it as a hallucinated function.
+- Do not flag a function or signature as invented, hallucinated, or wrong unless adaptor documentation provided to you in this evaluation contradicts it. You do not have reliable knowledge of adaptor APIs, and such flags have proven wrong. Without docs, judge only what is checkable from the code itself (JS syntax, state chaining, the rules in this file).
 - `each('$.path[*]', op)` uses JSONPath strings with the leading `$.`. Flag malformed JSONPath (e.g. missing `$.`, mismatched brackets) when the assistant clearly intends a JSONPath.
 - `cursor(...)` requires `@openfn/language-common` ≥ 1.13.0 — don't flag version mismatches unless the version is visible and clearly lower; the assistant rarely controls this.
 

--- a/services/testing/judges/openfn_workflow_expert.md
+++ b/services/testing/judges/openfn_workflow_expert.md
@@ -56,6 +56,7 @@ These mirror the workflow-generation contract. Reject the YAML if any are violat
 ## Out-of-scope concerns (do not grade)
 
 - The contents of `body` (the job code itself) — that's the code-quality judge's job. Even if you can see code in `body`, don't grade it here unless the issue is that code was written when it shouldn't have been.
+- Whether an adaptor function or signature used in code exists — never claim it doesn't unless adaptor documentation provided in this evaluation contradicts it; you do not have reliable knowledge of adaptor APIs.
 - Tone, conversational style, length of the textual explanation.
 - Whether the trailing `text` answer is well-phrased — only whether it contradicts the YAML or claims unsupported behavior.
 

--- a/services/testing/spec_collector.py
+++ b/services/testing/spec_collector.py
@@ -113,6 +113,13 @@ class SpecItem(pytest.Item):
         if text_path is not None:
             print(f"  ✓ response text saved to {text_path}")
 
+        # Fetched once per spec; all judges share it. None (no YAML / no DB /
+        # no docs) simply omits the block and judges fall back to their
+        # no-docs humility rules.
+        adaptor_docs = judge.build_adaptor_docs(_extract_yaml_from_response(response))
+        if adaptor_docs is not None:
+            print("  ✓ adaptor docs attached for judges")
+
         # One service call, N judges evaluate the same response in parallel.
         # Consensus: the test passes only if every judge passes.
         def _run_judge(judge_name: str) -> judge.Verdict:
@@ -121,6 +128,7 @@ class SpecItem(pytest.Item):
                 candidate=response,
                 test_notes=spec.notes or None,
                 request=payload,
+                adaptor_docs=adaptor_docs,
                 judge=judge_name,
             )
 


### PR DESCRIPTION
## Short Description

Adds golden tests of representative workflows, which surface a key quality issue in the global assistant: cross-step drift in job code generated in parallel. A prompt change allocates the responsibility of defining key and field names to the planner, before calling the job code agent instances. Another prompt tweak reinforces the planner/subagent boundary to prevent the planner from defining code structure except when specified by the user. 

Fixes #569 

## Implementation Details

###  Problem

When the planner builds a workflow, each step's code is written by an isolated job-code agent call that cannot see any other step. Steps therefore disagreed on how data passes between them, producing workflows that look right but fail at runtime. In the baseline 8-step fan-out run, the validate step wrote the patient to `state.event`, a later step read `state.validatedEvent`, and the FHIR step read `state.data` — every downstream field `undefined`. In the baseline Kobo run the steps shared a key but not its fields: validation stored `sex` and `dateOfBirth`, the update step read `gender` and `birthdate`.

###  Change

One block of the planner system prompt (`prompts.yaml`, "Tool Call Ordering"). The baseline had the planner describe shared data by a label only and forbade mentioning state. Now the planner puts an identical contract line in every job-code message: the exact state key (e.g. `state.patient`), the exact field names inside it (from the user's message when given, otherwise chosen once), and ownership — one step produces it, downstream steps consume it verbatim and translate into their own target system's format internally. How the code produces or consumes it stays the job agent's call. (An intermediate version fixing only the key still left field drift; only key + fields closed both.) This is the lightweight form of the mapping spec human OpenFn implementers write before coding — at this scale it is 5–30 field names.

###  Results

We generated the same six workflows (three scenarios, each from a vague and a verbose prompt) under the baseline prompt and the final prompt, and read each generated YAML checking only the issue this change targets: do the steps agree on where shared data lives? **Coherent** means every `state.X.y` a step reads was actually written by an upstream step under exactly that key and field name, so the data arrives at runtime. The two failure modes are **key drift** (steps use different state keys for the same data — the object never arrives) and **field drift** (same key, different field names inside it — the object arrives with empty fields). This is judged by reading the code, not by test pass/fail.

| Scenario (steps) | Baseline | Final |
|---|---|---|
| REST-to-REST vague (2) | coherent | coherent |
| REST-to-REST verbose (2) | coherent | coherent |
| Kobo→OpenMRS vague (2) | coherent | coherent |
| Kobo→OpenMRS verbose (5) | **field drift** — update reads `registration.gender`/`birthdate`, validate stored `sex`/`dateOfBirth`; error handler reads `submissionId` where the source has `_id` | coherent* |
| Fan-out vague (3–4) | coherent | coherent |
| Fan-out verbose (8) | **key + field drift** — `state.event` vs `state.validatedEvent` vs `state.data` across steps, plus `gender` vs `sex`; reproduced in two independent runs | coherent — all 8 steps read `state.patient` with the exact contract fields; `gender`/`birthDate` appear only inside target payloads (correct translation) |

\* One slip on an auxiliary value outside the contract (lookup stored a UUID string, update read `.uuid` off it); the contract object itself is clean.

Drift only ever appeared in the two verbose multi-system workflows — the ones with the most independently generated steps — and the final prompt eliminated it in both. The generated YAML for every cell is in `services/global_chat/tests/acceptance/gold_workflows/tmp/` (`__baseline` / `__fields-v2` labels).

###  Second change: requirements, not implementation

We found the planner occasionally prescribing code structure to subagents (e.g. telling one to put "placeholder constants at the top", which the job agent obeyed, producing invalid top-level declarations). The old guardrail only banned suggesting function names — an enumeration that misses everything not listed. It is replaced with the boundary itself: messages state what the step must do, must never do, and what it reads/writes per the contract — never what the code should look like; anything the user explicitly specified is a requirement and is relayed verbatim. Verified on two runs: the Kobo verbose scenario no longer gets structure prescriptions in planner messages, and the existing function-relay acceptance test (user names `each()`, `fields()`, `tracker.import` with `CREATE_AND_UPDATE`) still relays everything verbatim and now passes all criteria.

###  Future

For complex workflows a future version could generate a real, user-reviewable mapping artifact (including code-list/terminology mappings) or let job agents read upstream code directly. Not needed for workflows at this scale.


## AI Usage

Please disclose whether you've used AI in this work (it's cool, we just want to
know!):

- [x] Yes, I have not used AI
- [ ] No, I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
