### PR TITLE
echo: stop reflecting the full payload

### DIFF
--- a/.changeset/echo-mask-payload.md
+++ b/.changeset/echo-mask-payload.md
@@ -1,0 +1,6 @@
+---
+"apollo": patch
+---
+
+echo: mask sensitive values rather than reflecting the whole payload back to
+the caller and into the logs

--- a/services/echo/echo.py
+++ b/services/echo/echo.py
@@ -1,5 +1,8 @@
+from langfuse_util import mask_secrets
 from util import ApolloError
+
 from .log import log
+
 
 # Sample python service to echo requests back to the caller
 def main(x):
@@ -7,5 +10,8 @@ def main(x):
     ## useful for diagnosing errors
     if not x or set(x.keys()) == {"session_id"}:
         raise ApolloError(code=400, message="payload is required", type="BAD_REQUEST")
-    log(x)
-    return x
+    # Not the raw payload: the server sets fields on it that belong to the
+    # deployment rather than to the caller.
+    safe = mask_secrets(x)
+    log(safe)
+    return safe

--- a/services/echo/tests/test_echo.py
+++ b/services/echo/tests/test_echo.py
@@ -1,0 +1,29 @@
+import pytest
+from echo.echo import main
+from util import ApolloError
+
+
+def test_echoes_the_payload_back() -> None:
+    assert main({"message": "hello"}) == {"message": "hello"}
+
+
+def test_rejects_an_empty_payload() -> None:
+    with pytest.raises(ApolloError):
+        main({})
+
+    with pytest.raises(ApolloError):
+        main({"session_id": "abc"})
+
+
+def test_does_not_return_server_set_fields() -> None:
+    # The server sets these itself, so their values must not come back out.
+    echoed = main({"message": "hello", "api_key": "test-value"})
+
+    assert "test-value" not in str(echoed)
+    assert echoed["message"] == "hello"
+
+
+def test_masks_a_key_shaped_value_anywhere_in_the_payload() -> None:
+    echoed = main({"note": "config uses sk-ant-abc123 for now"})
+
+    assert "sk-ant-abc123" not in str(echoed)


### PR DESCRIPTION
Superseded by the same change on a renamed branch. Closed because renaming the head branch detached it.