### PR TITLE
Global chat: report which steps a status acted on

### DIFF
--- a/.changeset/global-chat-status-steps.md
+++ b/.changeset/global-chat-status-steps.md
@@ -1,0 +1,10 @@
+---
+"apollo": patch
+---
+
+Global chat: report which workflow steps a settled status acted on, as data
+rather than as names inside the sentence, so a client can attach per-step
+detail without parsing the prose. Each status also carries a shorter summary
+for clients that render that detail, so step names are not printed twice. Both
+fields are optional. Step names are no longer title-cased either, so a step the
+user called "Transform data" is no longer reported as "Transform Data"

--- a/services/global_chat/planner.py
+++ b/services/global_chat/planner.py
@@ -367,7 +367,13 @@ class PlannerAgent:
         """
         stream_manager.send_thinking(status)
 
-    def _send_settled(self, stream_manager, content: str | None) -> None:
+    def _send_settled(
+        self,
+        stream_manager,
+        content: str | None,
+        steps: list[dict] | None = None,
+        summary: str | None = None,
+    ) -> None:
         """Send a completed-action line ("Edited workflow structure") as a
         custom `status` event and record it in the transcript.
 
@@ -376,11 +382,24 @@ class PlannerAgent:
         are recorded in `response_segments` so a page reload re-renders the
         same view. None means the action left nothing worth showing (e.g. a
         consult that changed nothing) — nothing is sent or recorded.
+
+        `steps` carries which workflow steps this action touched, as data
+        rather than as names buried in `content`, so a client can attach
+        per-step detail without parsing the sentence. `summary` is the
+        shorter line such a client shows instead, so names are not printed
+        twice. Both are recorded alongside the segment so a reload has the
+        same information the live stream did.
         """
         if not content:
             return
-        stream_manager.send_status(content)
-        self._segments.append({"type": "status", "content": content})
+        stream_manager.send_status(content, steps=steps, summary=summary)
+
+        segment = {"type": "status", "content": content}
+        if steps:
+            segment["steps"] = steps
+        if summary:
+            segment["summary"] = summary
+        self._segments.append(segment)
 
     def _find_all_tool_uses(self, content):
         """Find all tool_use blocks in response content."""
@@ -615,7 +634,7 @@ class PlannerAgent:
 
         # Stitch results and update state sequentially
         tool_results = []
-        stitched_names = []
+        stitched_steps = []
         for block in blocks:
             if block.id in skipped:
                 tool_results.append(
@@ -643,7 +662,12 @@ class PlannerAgent:
                 self.current_yaml = stitch_job_code(self.current_yaml, matched_job_key, suggested_code)
                 self.yaml_modified = True
                 stitched = True
-                stitched_names.append(self._display_name_for_job(matched_job_key))
+                stitched_steps.append(
+                    {
+                        "key": matched_job_key,
+                        "name": self._display_name_for_job(matched_job_key),
+                    },
+                )
                 logger.info(f"Stitched code for job '{matched_job_key}' into current_yaml")
 
             self.subagent_results.append(subagent_result)
@@ -663,10 +687,18 @@ class PlannerAgent:
         # Settle the spinner with the steps that were actually applied (drop any
         # that failed to stitch); nothing sent if none applied. One YAML send
         # covers the whole batch, mirroring the one combined status.
-        if stitched_names:
+        if stitched_steps:
             self._send_yaml(stream_manager)
-            joined = ", ".join(f"\"{n}\"" for n in stitched_names)
-            self._send_settled(stream_manager, f"Wrote code for {joined}")
+            joined = ", ".join(f"\"{step['name']}\"" for step in stitched_steps)
+            count = len(stitched_steps)
+            self._send_settled(
+                stream_manager,
+                f"Wrote code for {joined}",
+                steps=stitched_steps,
+                # Clients that render a block per step get the count instead,
+                # so the names appear once, on the blocks.
+                summary=f"Wrote code for {count} step{'' if count == 1 else 's'}",
+            )
 
         return tool_results
 
@@ -738,8 +770,9 @@ class PlannerAgent:
     def _display_name_for_job(self, job_key: str | None) -> str | None:
         """Look up a human-readable display name for a job key.
 
-        Checks the workflow YAML for a name field first, then falls back
-        to title-casing the key (e.g. "fetch-patients" -> "Fetch Patients").
+        Returns the workflow YAML's own name for the job when it has one,
+        otherwise title-cases the key (e.g. "fetch-patients" -> "Fetch
+        Patients").
         """
         if not job_key:
             return None
@@ -747,7 +780,11 @@ class PlannerAgent:
         if self.current_yaml:
             _, job_data = find_job_in_yaml(self.current_yaml, job_key)
             if job_data and job_data.get("name"):
-                return self._format_display_name(job_data["name"])
+                # The user named this step; use it verbatim. Title-casing it
+                # renames "Transform data" to "Transform Data" in the prose,
+                # which then disagrees with the name shown everywhere else
+                # in the UI.
+                return job_data["name"]
 
         return self._format_display_name(job_key)
 

--- a/services/global_chat/tests/unit/test_planner.py
+++ b/services/global_chat/tests/unit/test_planner.py
@@ -46,14 +46,24 @@ class FakeToolUse:
 
 
 class StubStreamManager:
+    def __init__(self) -> None:
+        self.statuses: list[dict] = []
+
     def send_thinking(self, *_args: object, **_kwargs: object) -> None:
         pass
 
     def send_changes(self, *_args: object, **_kwargs: object) -> None:
         pass
 
-    def send_status(self, *_args: object, **_kwargs: object) -> None:
-        pass
+    def send_status(
+        self,
+        content: str,
+        steps: list | None = None,
+        summary: str | None = None,
+    ) -> None:
+        self.statuses.append(
+            {"content": content, "steps": steps, "summary": summary},
+        )
 
 
 def test_inspect_job_code_accepts_multiple_keys() -> None:
@@ -206,3 +216,60 @@ def test_user_content_falls_back_to_page_for_non_step_pages() -> None:
 
     assert "workflows/my-wf/settings" in user_content
     assert "currently viewing the step" not in user_content
+
+
+def test_step_name_is_taken_from_the_workflow_verbatim() -> None:
+    """The user named the step; title-casing it renames it in the prose."""
+    planner = make_planner()
+
+    assert planner._display_name_for_job("fetch-patients") == "Fetch Patients"
+    assert planner._display_name_for_job("load-dhis2") == "Load to DHIS2"
+
+
+def test_step_key_is_title_cased_only_as_a_fallback() -> None:
+    """With no name in the YAML there is nothing to preserve, so format the key."""
+    planner = make_planner()
+    planner.current_yaml = None
+
+    assert planner._display_name_for_job("fetch-patients") == "Fetch Patients"
+
+
+def test_settled_status_reports_its_steps_as_data() -> None:
+    planner = make_planner()
+    stream = StubStreamManager()
+
+    planner._send_settled(
+        stream,
+        'Wrote code for "Fetch Patients"',
+        steps=[{"key": "fetch-patients", "name": "Fetch Patients"}],
+        summary="Wrote code for 1 step",
+    )
+
+    # On the wire, so the client can attach detail without reading the prose
+    assert stream.statuses == [
+        {
+            "content": 'Wrote code for "Fetch Patients"',
+            "steps": [{"key": "fetch-patients", "name": "Fetch Patients"}],
+            "summary": "Wrote code for 1 step",
+        },
+    ]
+    # And in the transcript, so a reload has what the live stream had
+    assert planner._segments == [
+        {
+            "type": "status",
+            "content": 'Wrote code for "Fetch Patients"',
+            "steps": [{"key": "fetch-patients", "name": "Fetch Patients"}],
+            "summary": "Wrote code for 1 step",
+        },
+    ]
+
+
+def test_settled_status_without_steps_records_only_the_sentence() -> None:
+    planner = make_planner()
+    stream = StubStreamManager()
+
+    planner._send_settled(stream, "Edited workflow structure")
+
+    assert planner._segments == [
+        {"type": "status", "content": "Edited workflow structure"},
+    ]

--- a/services/streaming_util.py
+++ b/services/streaming_util.py
@@ -319,7 +319,12 @@ class StreamManager:
         self._close_open_blocks()
         self._emit_event('changes', changes_data)
 
-    def send_status(self, content: str) -> None:
+    def send_status(
+        self,
+        content: str,
+        steps: list[dict] | None = None,
+        summary: str | None = None,
+    ) -> None:
         """
         Send a completed-action status ("Edited workflow structure") as a
         custom `status` SSE event.
@@ -330,12 +335,26 @@ class StreamManager:
         are durable facts about what happened, which the client keeps. The
         payload matches the `response_segments` entry shape so the client
         can render live events and reloaded segments with the same code.
+
+        `steps` names the workflow steps this action touched, as data:
+        `[{"key": "transform-data", "name": "Transform data"}]`. A client
+        that renders per-step detail uses it to attach that detail to this
+        status without parsing `content`. `summary` is a shorter line for
+        those clients, so the step names are not printed twice; clients
+        that render prose only keep using `content`. Both are omitted from
+        the payload when absent, so this stays additive.
         """
         if not self.stream_started:
             self.start_stream()
 
+        payload = {"type": "status", "content": content}
+        if steps:
+            payload["steps"] = steps
+        if summary:
+            payload["summary"] = summary
+
         self._close_open_blocks()
-        self._emit_event('status', {"type": "status", "content": content})
+        self._emit_event('status', payload)
 
     def end_stream(self, stop_reason: str = "end_turn") -> None:
         """


### PR DESCRIPTION
## Short Description

Settled statuses in the global chat now report which workflow steps they acted on as data, so a client can attach per-step detail without reading the sentence. Also stops title-casing a step's own name.

Fixes #

## Implementation Details

The planner already knows exactly which steps it wrote. It holds the `job_key` from the tool call, resolves it to the key that matched in the YAML, and then throws all of that away into an English sentence. Anything downstream that wants to know what an action touched has to parse the prose back out, which is what OpenFn/lightning#5100 was doing with a regex over write verbs and a substring match on step names.

`_send_settled` now takes the steps alongside the line, and `send_status` puts them on the wire:

```json
{"type":"status",
 "content":"Wrote code for \"Transform data\", \"Send to Gmail\"",
 "steps":[{"key":"transform-data","name":"Transform data"},
          {"key":"send-to-gmail","name":"Send to Gmail"}],
 "summary":"Wrote code for 2 steps"}
```

`summary` is there because a client that renders the steps as detail would otherwise print their names twice, once in the sentence and again on each block. Both fields are omitted when absent, so a client reading only `content` sees no change at all. The same shape is recorded in `response_segments`, so a reloaded transcript has what the live stream had.

The casing fix is separate but sat in the same function. `_display_name_for_job` looks the name up in the workflow YAML and then ran `_format_display_name` over it, so a step the user called "Transform data" came back as "Transform Data" and disagreed with the name shown everywhere else in Lightning. Title-casing is right for the fallback, where all we have is a key like `fetch-patients`, and wrong for a name the user chose. It now applies only to the fallback.

Verified against a real streamed reply rather than only in tests: the `status` event carries the steps, and the names match the workflow's own casing.

## AI Usage

Please disclose whether you've used AI in this work (it's cool, we just want to know!):

- [x] Yes, I have used AI
- [ ] No, I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
